### PR TITLE
AI Insights: review-driven quality & correctness fixes

### DIFF
--- a/StillView - Simple Image Viewer Tests/Services/ImageContentTypeClassifierTests.swift
+++ b/StillView - Simple Image Viewer Tests/Services/ImageContentTypeClassifierTests.swift
@@ -26,6 +26,35 @@ final class ImageContentTypeClassifierTests: XCTestCase {
         XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .document)
     }
 
+    func test_moderateTextWithDocumentClassificationReturnsDocument() {
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "screenshot", confidence: 0.7)],
+            recognizedText: [
+                "StillView Release Notes",
+                "AI Insights",
+                "On-device analysis",
+                "No network requests"
+            ],
+            faceCount: 0,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+
+        XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .document)
+    }
+
+    func test_shortSignTextWithoutDocumentClassificationDoesNotReturnDocument() {
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "building", confidence: 0.6)],
+            recognizedText: ["OPEN", "MAIN ST"],
+            faceCount: 0,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+
+        XCTAssertNotEqual(ImageContentTypeClassifier.classify(perception), .document)
+    }
+
     // MARK: - Group (Priority 2)
 
     func test_multipleFacesReturnsGroup() {
@@ -115,6 +144,33 @@ final class ImageContentTypeClassifierTests: XCTestCase {
         XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .object)
     }
 
+    func test_genericPeopleClassificationWithoutFacesDoesNotReturnObject() {
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "people", confidence: 0.85)],
+            recognizedText: [],
+            faceCount: 0,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+
+        XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .general)
+    }
+
+    func test_strongEligibleSecondClassificationCanReturnObject() {
+        let perception = ImagePerceptionResult(
+            classifications: [
+                .init(identifier: "indoor", confidence: 0.9),
+                .init(identifier: "dog", confidence: 0.82)
+            ],
+            recognizedText: [],
+            faceCount: 0,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+
+        XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .object)
+    }
+
     func test_weakClassificationDoesNotReturnObject() {
         let perception = ImagePerceptionResult(
             classifications: [.init(identifier: "food", confidence: 0.5)],
@@ -164,11 +220,86 @@ final class ImageContentTypeClassifierTests: XCTestCase {
         XCTAssertEqual(profile.maxTokens, 600)
     }
 
-    func test_retryProfileBumpsTemperature() {
+    func test_retryProfileTightensSampling() {
         let base = GenerationProfile.profile(for: .portrait)
         let retry = base.retryProfile
-        XCTAssertEqual(retry.temperature, base.temperature + 0.15, accuracy: 0.001)
-        XCTAssertEqual(retry.topK, base.topK)
+        XCTAssertEqual(retry.temperature, base.temperature - 0.1, accuracy: 0.001)
+        XCTAssertEqual(retry.topK, 2)
         XCTAssertEqual(retry.maxTokens, base.maxTokens)
+    }
+
+    // MARK: - ROUTE-1: horizonless outdoor scenes
+
+    func test_horizonlessOutdoorSceneWithNoForegroundReturnsLandscape() {
+        // A forest/dune scene with no detected horizon and no distinct foreground subject
+        // is still a landscape, not a fall-through to .general.
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "forest", confidence: 0.62)],
+            recognizedText: [],
+            faceCount: 0,
+            salientObjectCount: 0,
+            hasHorizon: false
+        )
+        XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .landscape)
+    }
+
+    func test_outdoorSceneWithForegroundSubjectStaysObject() {
+        // A strong foreground subject in an outdoor scene must stay .object — the
+        // salientObjectCount == 0 gate keeps object-in-outdoor photos out of .landscape.
+        let perception = ImagePerceptionResult(
+            classifications: [
+                .init(identifier: "dog", confidence: 0.85),
+                .init(identifier: "park", confidence: 0.6)
+            ],
+            recognizedText: [],
+            faceCount: 0,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+        XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .object)
+    }
+
+    // MARK: - ROUTE-4: ID cards / badges route to document
+
+    func test_idCardWithFaceRoutesToDocument() {
+        // A loosely-shot ID card has one face and only a few text lines, so it used to route
+        // to .portrait; the card classification should make it read as a document instead.
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "id_card", confidence: 0.6)],
+            recognizedText: ["LICENSE", "John Doe", "Class C"],
+            faceCount: 1,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+        XCTAssertEqual(ImageContentTypeClassifier.classify(perception), .document)
+    }
+
+    // MARK: - PROFILE-1: failure-aware retry profile
+
+    func test_retryProfileHoldsSteadyForUnderSpecification() {
+        // Empty/generic output is made worse by tightening — hold sampling steady so the model
+        // keeps freedom to weave in weaker signals; the correctionHint does the corrective work.
+        let base = GenerationProfile.profile(for: .general)
+        let retry = base.retryProfile(for: [.emptyDespiteSignals])
+
+        XCTAssertEqual(retry.temperature, base.temperature, accuracy: 0.001)
+        XCTAssertEqual(retry.topK, base.topK)
+    }
+
+    func test_retryProfileTightensForLeakage() {
+        let base = GenerationProfile.profile(for: .general)
+        let retry = base.retryProfile(for: [.cameraModelTitle])
+
+        XCTAssertEqual(retry.temperature, base.temperature - 0.1, accuracy: 0.001)
+        XCTAssertEqual(retry.topK, 2)
+    }
+
+    func test_retryProfileTightensForMixedFailures() {
+        // A mix of under-specification and leakage must default to the safe (tightened) path.
+        let base = GenerationProfile.profile(for: .general)
+        let retry = base.retryProfile(for: [.emptyDespiteSignals, .cameraModelTitle])
+
+        XCTAssertEqual(retry.temperature, base.temperature - 0.1, accuracy: 0.001)
+        XCTAssertEqual(retry.topK, 2)
     }
 }

--- a/StillView - Simple Image Viewer Tests/Services/ImagePerceptionServiceTests.swift
+++ b/StillView - Simple Image Viewer Tests/Services/ImagePerceptionServiceTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import StillView___Simple_Image_Viewer
+
+final class ImagePerceptionServiceTests: XCTestCase {
+
+    // MARK: - shouldCountFace (PERCEPT-2)
+    // Extracted from the Vision face-rectangles filter so the routing-critical
+    // portrait-vs-group predicate is unit-testable. A face counts when it occupies a
+    // reasonable area OR is high-confidence.
+
+    func test_shouldCountFace_largeAreaLowConfidence_counts() {
+        // A clearly-sized foreground face (~0.8% of frame) at modest confidence — a bar photo.
+        XCTAssertTrue(ImagePerceptionService.shouldCountFace(area: 0.008, confidence: 0.6))
+    }
+
+    func test_shouldCountFace_tinyLowConfidence_doesNotCount() {
+        // A tiny, low-confidence blob (background noise) is rejected.
+        XCTAssertFalse(ImagePerceptionService.shouldCountFace(area: 0.001, confidence: 0.4))
+    }
+
+    func test_shouldCountFace_tinyHighConfidence_counts() {
+        // A small but high-confidence face (distant but real) is rescued by the confidence arm.
+        XCTAssertTrue(ImagePerceptionService.shouldCountFace(area: 0.001, confidence: 0.85))
+    }
+
+    // MARK: - OCRCleaner single-character CJK (PERCEPT-3)
+
+    func test_clean_keepsSingleCharCJKSign() {
+        // OCR languages include ja/zh-Hans/ko; a single-character sign (e.g. 出 = "exit")
+        // must survive rather than be dropped by the 2-character floor.
+        let cleaned = OCRCleaner.clean(["出", "A"])
+        XCTAssertTrue(cleaned.contains("出"), "Single-character CJK signage should be kept, got: \(cleaned)")
+    }
+
+    func test_clean_stillDropsStraySingleLatinChar() {
+        // The relaxation is CJK-specific; a stray single Latin character is still noise.
+        let cleaned = OCRCleaner.clean(["A", "Cafe"])
+        XCTAssertFalse(cleaned.contains("A"))
+        XCTAssertTrue(cleaned.contains("Cafe"))
+    }
+}

--- a/StillView - Simple Image Viewer Tests/Services/InsightOutputValidatorTests.swift
+++ b/StillView - Simple Image Viewer Tests/Services/InsightOutputValidatorTests.swift
@@ -26,6 +26,26 @@ final class InsightOutputValidatorTests: XCTestCase {
         XCTAssertEqual(validation, .passed)
     }
 
+    func test_cameraModelInTagsFailsValidation() {
+        let result = ImageInsightResult(
+            title: "Garden flowers",
+            summary: "A bed of flowers fills the frame.",
+            likelyContent: "Flowering plants in a garden.",
+            usefulDetails: ["Visual categories include flower and plant"],
+            tags: ["flower", "iPhone 15 Pro"],
+            limitations: ["Cannot identify the exact plant species."]
+        )
+        let input = makeInput(cameraSignals: ["Camera: Apple iPhone 15 Pro"])
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.cameraModelLeakage))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
     // MARK: - Generic Filler Title
 
     func test_genericFillerTitleFailsValidation() {
@@ -69,12 +89,33 @@ final class InsightOutputValidatorTests: XCTestCase {
         }
     }
 
-    func test_defaultTitleWithoutSignalsPasses() {
+    func test_defaultTitleWithoutSignalsFailsAsGenericFiller() {
         let result = makeResult(title: "Local Image Insight")
         let input = makeInput(visualSignals: [])
 
         let validation = InsightOutputValidator.validate(result, input: input)
-        XCTAssertEqual(validation, .passed)
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.genericFillerTitle))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    func test_defaultSummaryWithSignalsFailsValidation() {
+        let result = makeResult(
+            title: "Flower close-up",
+            summary: "Generated from local file metadata and available system signals."
+        )
+        let input = makeInput(visualSignals: ["Scene/object categories: flower (88%)"])
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.emptyDespiteSignals))
+        } else {
+            XCTFail("Expected validation failure")
+        }
     }
 
     // MARK: - EXIF-Driven Content
@@ -128,6 +169,58 @@ final class InsightOutputValidatorTests: XCTestCase {
         }
     }
 
+    func test_titleMostlyComposedFromOCRWordsFailsValidation() {
+        let result = makeResult(title: "Welcome San Francisco Gate 42")
+        let input = ImageInsightInput(
+            fileName: "test.jpg",
+            fileType: "JPEG",
+            dimensions: "1000x1000",
+            fileSize: "1 MB",
+            visualSignals: ["Text visible in image (OCR): WELCOME TO SAN FRANCISCO | Gate 42"],
+            imageURL: nil
+        )
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.rawOCRDump))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    // MARK: - File Name Leakage
+
+    func test_fileNameAsTitleFailsValidation() {
+        let result = makeResult(title: "summer garden")
+        let input = makeInput(fileName: "summer-garden.jpg")
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.fileNameTitle))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    // MARK: - Prompt Scaffold Leakage
+
+    func test_suitcaseConceptPassesWhenSupportedByVisionEvidence() {
+        let result = ImageInsightResult(
+            title: "Suitcase on table",
+            summary: "A suitcase appears to be sitting on a table.",
+            likelyContent: "A suitcase or travel bag is the likely subject.",
+            usefulDetails: ["Top visual category is suitcase"],
+            tags: ["suitcase", "travel bag"],
+            limitations: ["Cannot determine the suitcase brand."]
+        )
+        let input = makeInput(visualSignals: ["Scene/object categories: suitcase (88%), travel bag (72%)"])
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+        XCTAssertEqual(validation, .passed)
+    }
+
     // MARK: - Multiple Failures
 
     func test_multipleFailuresReportedTogether() {
@@ -173,6 +266,212 @@ final class InsightOutputValidatorTests: XCTestCase {
         XCTAssertTrue(hint.contains("specific"))
     }
 
+    // MARK: - Fallback
+
+    func test_groundedFallbackAvoidsCameraAndFilenameLeakage() {
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "sports_car", confidence: 0.86)],
+            recognizedText: [],
+            faceCount: 0,
+            salientObjectCount: 1,
+            hasHorizon: false
+        )
+        let input = makeInput(
+            fileName: "iphone-capture.jpg",
+            visualSignals: perception.asSignals,
+            cameraSignals: ["Camera: Apple iPhone 15 Pro"]
+        )
+
+        let result = ImageInsightFallbackBuilder.result(for: input, perception: perception, type: .object)
+        let validation = InsightOutputValidator.validate(result, input: input)
+
+        XCTAssertEqual(validation, .passed)
+        XCTAssertFalse(result.title.lowercased().contains("iphone"))
+    }
+
+    // MARK: - FALLBACK-1: document fallback surfaces OCR text
+
+    func test_documentFallbackTitleIncludesOCRText() {
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "document", confidence: 0.8)],
+            recognizedText: ["Invoice #4021", "Total due: $58.00"],
+            faceCount: 0,
+            salientObjectCount: 0,
+            hasHorizon: false
+        )
+        let input = makeInput(visualSignals: perception.asSignals)
+
+        let result = ImageInsightFallbackBuilder.result(for: input, perception: perception, type: .document)
+
+        XCTAssertTrue(result.title.contains("Invoice"), "Document fallback title should surface OCR text, got: \(result.title)")
+        XCTAssertNotEqual(result.title, "Readable text in image")
+    }
+
+    // MARK: - FALLBACK-2: low-confidence label must not become a confident title
+
+    func test_fallbackTitleHedgesWhenTopLabelIsLowConfidence() {
+        let perception = ImagePerceptionResult(
+            classifications: [.init(identifier: "blur", confidence: 0.22)],
+            recognizedText: [],
+            faceCount: 0,
+            salientObjectCount: 0,
+            hasHorizon: false
+        )
+        let input = makeInput(visualSignals: perception.asSignals)
+
+        let result = ImageInsightFallbackBuilder.result(for: input, perception: perception, type: .general)
+
+        XCTAssertFalse(
+            result.title.lowercased().contains("blur"),
+            "A 22%-confidence label must not be stated as a confident title, got: \(result.title)"
+        )
+    }
+
+    // MARK: - VALID-1: scaffold check removed (no false positives)
+
+    func test_legitimateLeatherSuitcasePhotoPasses() {
+        // Apple Vision emits a synonym ("luggage"), not the literal "leather"/"suitcase",
+        // so the deleted scaffold check used to false-positive this correct description.
+        let result = ImageInsightResult(
+            title: "Leather suitcase on a table",
+            summary: "A brown leather suitcase rests on a wooden table.",
+            likelyContent: "A piece of luggage is the main subject.",
+            usefulDetails: ["A single foreground subject"],
+            tags: ["luggage", "bag"],
+            limitations: ["Cannot determine the brand."]
+        )
+        let input = makeInput(visualSignals: ["Scene/object categories (Apple Vision, with confidence): luggage (88%), bag (72%)"])
+
+        XCTAssertEqual(InsightOutputValidator.validate(result, input: input), .passed)
+    }
+
+    // MARK: - VALID-2: missing generic prefix
+
+    func test_aPhotoOfPrefixFailsValidation() {
+        let result = makeResult(title: "A photo of a sunset")
+        let validation = InsightOutputValidator.validate(result, input: makeInput())
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.genericFillerTitle))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    // MARK: - VALID-3 / CONSIST-4: single-token camera names
+
+    func test_singleTokenCameraNameInTitleFails() {
+        let result = makeResult(title: "DJI aerial shot over the bay")
+        let input = makeInput(cameraSignals: ["Camera: DJI"])
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.cameraModelTitle))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    func test_cameraBrandHomonymInTitlePasses() {
+        // "Apple" is a camera make AND a fruit; a multi-token make where only the brand word
+        // appears in the title must not trip the single-token rule.
+        let result = makeResult(title: "Apple orchard at sunset")
+        let input = makeInput(cameraSignals: ["Camera: Apple iPhone 15"])
+
+        XCTAssertEqual(InsightOutputValidator.validate(result, input: input), .passed)
+    }
+
+    func test_singleTokenPhoneMakeHomonymPasses() {
+        // Phone EXIF often reports `make` as a single brand word that is also a legitimate
+        // subject (a store, a campus). A bare make like "Samsung" must not be flagged as a
+        // camera-model title — that brand word naming real content is not EXIF leakage.
+        let result = makeResult(title: "Samsung store at the mall")
+        let input = makeInput(cameraSignals: ["Camera: Samsung"])
+
+        XCTAssertEqual(InsightOutputValidator.validate(result, input: input), .passed)
+    }
+
+    // MARK: - CONSIST-2 / CONSIST-6: type-specific forbidden titles enforced
+
+    func test_typeSpecificForbiddenTitlesFailValidation() {
+        let forbidden = [
+            "A person standing in a field",
+            "Portrait of someone",
+            "A group of people",
+            "Several individuals together",
+            "Text on a screen",
+            "A document showing details",
+            "A beautiful landscape",
+            "A scenic view of the hills",
+            "Nature scene",
+            "An object on a surface",
+            "A photo of an item",
+            "Selfie",
+            "Portrait"
+        ]
+        for title in forbidden {
+            let validation = InsightOutputValidator.validate(makeResult(title: title), input: makeInput())
+            if case .failed(let reasons) = validation {
+                XCTAssertTrue(reasons.contains(.genericFillerTitle), "Expected '\(title)' to be flagged as generic filler")
+            } else {
+                XCTFail("Expected '\(title)' to fail validation")
+            }
+        }
+    }
+
+    // MARK: - CONSIST-5: parroted scaffold example caught without camera metadata
+
+    func test_parrotedScaffoldExampleTitleFailsWithoutCameraMetadata() {
+        let result = makeResult(title: "iPhone 13 Pro Max Capture")
+        let validation = InsightOutputValidator.validate(result, input: makeInput()) // no cameraSignals
+
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.genericFillerTitle))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    // MARK: - VALID-4: filename leakage beyond exact match
+
+    func test_fileNameLeakWithExtraWordFails() {
+        let result = makeResult(title: "Summer garden scene")
+        let input = makeInput(fileName: "summer-garden.jpg") // no visual support
+
+        let validation = InsightOutputValidator.validate(result, input: input)
+        if case .failed(let reasons) = validation {
+            XCTAssertTrue(reasons.contains(.fileNameTitle))
+        } else {
+            XCTFail("Expected validation failure")
+        }
+    }
+
+    func test_descriptiveFilenameSupportedByVisionPasses() {
+        let result = makeResult(title: "Summer garden")
+        let input = makeInput(
+            fileName: "summer-garden.jpg",
+            visualSignals: ["Scene/object categories (Apple Vision, with confidence): garden (88%), flower (72%)"]
+        )
+
+        XCTAssertEqual(InsightOutputValidator.validate(result, input: input), .passed)
+    }
+
+    // MARK: - CONSIST-1: short signs may be named after their own text
+
+    func test_shortSignTitleNamedAfterItsOwnTextPasses() {
+        let result = makeResult(title: "Closed For Renovation")
+        let input = ImageInsightInput(
+            fileName: "store.jpg",
+            fileType: "JPEG",
+            dimensions: "1000x1000",
+            fileSize: "1 MB",
+            visualSignals: ["Text visible in image (OCR — brand names, venue names, signage, banners): Closed For Renovation"],
+            imageURL: nil
+        )
+
+        XCTAssertEqual(InsightOutputValidator.validate(result, input: input), .passed)
+    }
+
     // MARK: - Helpers
 
     private func makeResult(
@@ -190,11 +489,12 @@ final class InsightOutputValidatorTests: XCTestCase {
     }
 
     private func makeInput(
+        fileName: String = "test.jpg",
         visualSignals: [String] = [],
         cameraSignals: [String] = []
     ) -> ImageInsightInput {
         ImageInsightInput(
-            fileName: "test.jpg",
+            fileName: fileName,
             fileType: "JPEG image",
             dimensions: "4000 x 3000",
             fileSize: "3 MB",

--- a/StillView - Simple Image Viewer Tests/Smoke/ImageInsightTests.swift
+++ b/StillView - Simple Image Viewer Tests/Smoke/ImageInsightTests.swift
@@ -78,7 +78,11 @@ final class ImageInsightCoreTests: XCTestCase {
             "Legends Club",
             "REWER",
             "Acme",
-            "Ferrari"
+            "Ferrari",
+            "vintage leather suitcase",
+            "classic design",
+            "well-worn texture",
+            "timeless style"
         ]
         for leak in forbiddenLeakStrings {
             XCTAssertFalse(

--- a/StillView - Simple Image Viewer.xcodeproj/project.pbxproj
+++ b/StillView - Simple Image Viewer.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		B2010000000000000000000D /* ImagePerceptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2010000000000000000000E /* ImagePerceptionService.swift */; };
 		B201000000000000000000F1 /* ImageContentTypeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B201000000000000000000F2 /* ImageContentTypeClassifier.swift */; };
 		B201000000000000000000F3 /* ImageContentTypeClassifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B201000000000000000000F4 /* ImageContentTypeClassifierTests.swift */; };
+		B2010000000000000000AA01 /* ImagePerceptionServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2010000000000000000AA02 /* ImagePerceptionServiceTests.swift */; };
 		B201000000000000000000F6 /* ImageContentTypeClassifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = B201000000000000000000F2 /* ImageContentTypeClassifier.swift */; };
 		B201000000000000000000F7 /* ImagePerceptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2010000000000000000000E /* ImagePerceptionService.swift */; };
 		B201000000000000000000F8 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB2E7C922E556A5F000525C4 /* Logger.swift */; };
@@ -164,6 +165,7 @@
 		B2010000000000000000000E /* ImagePerceptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePerceptionService.swift; sourceTree = "<group>"; };
 		B201000000000000000000F2 /* ImageContentTypeClassifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageContentTypeClassifier.swift; sourceTree = "<group>"; };
 		B201000000000000000000F4 /* ImageContentTypeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageContentTypeClassifierTests.swift; sourceTree = "<group>"; };
+		B2010000000000000000AA02 /* ImagePerceptionServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePerceptionServiceTests.swift; sourceTree = "<group>"; };
 		B201000000000000000000A2 /* InsightOutputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightOutputValidator.swift; sourceTree = "<group>"; };
 		B201000000000000000000A4 /* InsightOutputValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightOutputValidatorTests.swift; sourceTree = "<group>"; };
 		C0C0C0C0C0C0C0C0C0C0C0E1 /* StillView - Simple Image Viewer Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "StillView - Simple Image Viewer Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -453,6 +455,7 @@
 			isa = PBXGroup;
 			children = (
 				B201000000000000000000F4 /* ImageContentTypeClassifierTests.swift */,
+				B2010000000000000000AA02 /* ImagePerceptionServiceTests.swift */,
 				B201000000000000000000A4 /* InsightOutputValidatorTests.swift */,
 			);
 			path = Services;
@@ -679,6 +682,7 @@
 				B201000000000000000000F7 /* ImagePerceptionService.swift in Sources */,
 				B201000000000000000000F8 /* Logger.swift in Sources */,
 				B201000000000000000000F3 /* ImageContentTypeClassifierTests.swift in Sources */,
+				B2010000000000000000AA01 /* ImagePerceptionServiceTests.swift in Sources */,
 				B201000000000000000000A5 /* InsightOutputValidator.swift in Sources */,
 				B201000000000000000000A3 /* InsightOutputValidatorTests.swift in Sources */,
 				C0C0C0C0C0C0C0C0C0C0C0D1 /* SmokeTests.swift in Sources */,
@@ -821,7 +825,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"StillView - Simple Image Viewer/Preview Content\"";
 				ENABLE_APP_SANDBOX = YES;
@@ -848,7 +852,7 @@
 					"\"$(SRCROOT)/StillView - Simple Image Viewer/Models\"",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 4.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vinny.StillView-Image-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -865,7 +869,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 30;
+				CURRENT_PROJECT_VERSION = 31;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"StillView - Simple Image Viewer/Preview Content\"";
 				"DEVELOPMENT_TEAM[sdk=macosx*]" = 52HVJ3VDSM;
@@ -893,7 +897,7 @@
 					"\"$(SRCROOT)/StillView - Simple Image Viewer/Models\"",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 4.0.0;
+				MARKETING_VERSION = 4.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.vinny.StillView-Image-Viewer";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/StillView - Simple Image Viewer.xcodeproj/project.pbxproj
+++ b/StillView - Simple Image Viewer.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		B20100000000000000000001 /* ImageInsightCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20100000000000000000002 /* ImageInsightCore.swift */; };
 		B20100000000000000000003 /* ImageInsightViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20100000000000000000004 /* ImageInsightViewModel.swift */; };
 		B20100000000000000000005 /* AppleIntelligenceInsightsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20100000000000000000006 /* AppleIntelligenceInsightsService.swift */; };
+		B2010000000000000000AA05 /* InsightEvalHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2010000000000000000AA06 /* InsightEvalHarness.swift */; };
 		B20100000000000000000007 /* ImageInsightPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20100000000000000000008 /* ImageInsightPanelView.swift */; };
 		B20100000000000000000009 /* ImageInsightCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20100000000000000000002 /* ImageInsightCore.swift */; };
 		B2010000000000000000000A /* ImageInsightViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20100000000000000000004 /* ImageInsightViewModel.swift */; };
@@ -160,6 +161,7 @@
 		B20100000000000000000002 /* ImageInsightCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageInsightCore.swift; sourceTree = "<group>"; };
 		B20100000000000000000004 /* ImageInsightViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageInsightViewModel.swift; sourceTree = "<group>"; };
 		B20100000000000000000006 /* AppleIntelligenceInsightsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleIntelligenceInsightsService.swift; sourceTree = "<group>"; };
+		B2010000000000000000AA06 /* InsightEvalHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightEvalHarness.swift; sourceTree = "<group>"; };
 		B20100000000000000000008 /* ImageInsightPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageInsightPanelView.swift; sourceTree = "<group>"; };
 		B2010000000000000000000C /* ImageInsightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageInsightTests.swift; sourceTree = "<group>"; };
 		B2010000000000000000000E /* ImagePerceptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePerceptionService.swift; sourceTree = "<group>"; };
@@ -298,6 +300,7 @@
 			isa = PBXGroup;
 			children = (
 				B20100000000000000000006 /* AppleIntelligenceInsightsService.swift */,
+				B2010000000000000000AA06 /* InsightEvalHarness.swift */,
 				B2010000000000000000000E /* ImagePerceptionService.swift */,
 				B201000000000000000000F2 /* ImageContentTypeClassifier.swift */,
 				B201000000000000000000A2 /* InsightOutputValidator.swift */,
@@ -584,6 +587,7 @@
 				B20100000000000000000001 /* ImageInsightCore.swift in Sources */,
 				B20100000000000000000003 /* ImageInsightViewModel.swift in Sources */,
 				B20100000000000000000005 /* AppleIntelligenceInsightsService.swift in Sources */,
+				B2010000000000000000AA05 /* InsightEvalHarness.swift in Sources */,
 				B2010000000000000000000D /* ImagePerceptionService.swift in Sources */,
 				B201000000000000000000F1 /* ImageContentTypeClassifier.swift in Sources */,
 				B201000000000000000000A1 /* InsightOutputValidator.swift in Sources */,

--- a/StillView - Simple Image Viewer/App/SimpleImageViewerApp.swift
+++ b/StillView - Simple Image Viewer/App/SimpleImageViewerApp.swift
@@ -73,6 +73,14 @@ struct SimpleImageViewerApp: App {
         }
         .windowResizability(.contentSize)
         .commands {
+            #if DEBUG
+            CommandMenu("Debug") {
+                Button("Run AI Insights Eval…") {
+                    InsightEvalHarness.presentAndRun()
+                }
+            }
+            #endif
+
             // Add About menu command
             CommandGroup(replacing: .appInfo) {
                 Button("About StillView") {

--- a/StillView - Simple Image Viewer/Models/ImageInsightCore.swift
+++ b/StillView - Simple Image Viewer/Models/ImageInsightCore.swift
@@ -8,7 +8,8 @@ import Foundation
 ///      Primary evidence for "what is in the image."
 ///   2. `metadataDescription` + `keywords` — embedded file metadata (often user-authored).
 ///      Secondary evidence.
-///   3. `cameraSignals` — camera/EXIF/GPS. Context only; must never be the title or subject.
+///   3. `cameraSignals` + file details — camera/EXIF/GPS.
+///      Context only; must never be the title or subject.
 struct ImageInsightInput: Equatable, Sendable {
     let fileName: String
     let fileType: String
@@ -237,10 +238,10 @@ protocol ImageInsightGenerating: Sendable {
 enum ImageInsightPromptBuilder {
     static let systemInstruction = """
     You describe the visible content of a local image for a minimalist macOS image viewer. \
-    Your job is to NAME what is in the image using ONLY the on-device Vision signals provided in \
+    Your job is to NAME what is in the image using the on-device Vision signals provided in \
     the current prompt. Do not use any text, names, places, or examples from this instruction \
     block as if they were observations of the image — only the data under "PRIMARY EVIDENCE" in \
-    the user prompt counts.
+    the user prompt counts as visual evidence.
 
     RULES (in order of importance):
 
@@ -250,21 +251,19 @@ enum ImageInsightPromptBuilder {
        Garbled fragments may need interpretation; pick the cleanest, longest tokens. If OCR is \
        empty or absent for THIS image, NEVER invent venue or brand names.
 
-    2. FACE COUNT is the ONLY source of truth for "people in the photo." If the PRIMARY \
-       EVIDENCE has no "Faces detected" line, the photo has NO people as subjects — do not \
-       describe it as a portrait, group photo, or social gathering. The subject is whatever \
-       else the evidence shows (flowers, food, a vehicle, a building, etc.). \
+    2. FACE COUNT is the strongest source of truth for people as primary subjects. \
        If "Faces detected: N" is present: 1 = portrait or selfie, 2-4 = small group, 5+ = \
-       group photo.
+       group photo. If there is no "Faces detected" line, do not make people the main subject \
+       solely from generic "person", "people", or "adult" classifications. Mention people only \
+       cautiously when another strong signal supports it.
 
-    3. Use the scene/object classifications from PRIMARY EVIDENCE to set the scene. Name the \
-       dominant categories that actually appear in the evidence. When confidence is high (>0.7) \
-       state the category as fact; when low (<0.5) hedge with "appears to be." Classifications \
-       like "people", "adult", or "person" may reflect background figures in a still-life photo, \
-       NOT the subject. Never describe the image as a photo OF people unless Rule 2 says so.
+    3. Use scene/object classifications from PRIMARY EVIDENCE to set the scene, but weigh them \
+       by confidence. Name high-confidence categories (>0.7) directly. Hedge low-confidence \
+       categories (<0.5) with "appears to be" or omit them if they conflict with stronger signals. \
+       Generic labels like "indoor", "outdoor", "person", or "people" are context, not a title.
 
     4. Do not infer people, events, parties, celebrations, weddings, gatherings, or activities \
-       from object types (e.g. flowers, food, decorations) or from the file name. Only describe \
+       from object types such as flowers, food, or decorations, or from the file name. Only describe \
        what the evidence explicitly supports.
 
     5. Camera, lens, GPS, and EXIF metadata are CONTEXT ONLY. Never use the camera model, lens, \
@@ -272,9 +271,9 @@ enum ImageInsightPromptBuilder {
        "iPhone 13 Pro Max Capture" is forbidden — describe the photograph's content instead.
 
     6. If PRIMARY EVIDENCE is genuinely sparse (no OCR, weak classifications, no faces), be \
-       honest: describe at the level of detail the evidence supports. Do not invent named \
-       individuals, venues, brands, exact locations, or specific events that aren't in the \
-       evidence for this specific image.
+       honest in the summary and limitations: describe only the level of detail the evidence \
+       supports. Do not invent named individuals, venues, brands, exact locations, or specific \
+       events that are not in the evidence for this specific image.
     """
 
     static func prompt(for input: ImageInsightInput, type: ImageContentType = .general) -> String {
@@ -300,7 +299,7 @@ enum ImageInsightPromptBuilder {
 
     private static func portraitPrompt(evidence: String) -> String {
         """
-        This image contains one person as the primary subject.
+        This image has one detected face and likely has one person as the primary subject.
 
         YOUR TASK: Describe what the person appears to be doing, their setting, and any notable \
         visual context (clothing, activity, environment). Focus on the person as subject.
@@ -308,7 +307,9 @@ enum ImageInsightPromptBuilder {
         TITLE: Name the activity or scene, not "a person standing" or "portrait of someone." \
         Pattern: "[Activity/attribute] [setting]"
 
-        FORBIDDEN in title: "A person standing", "Portrait of someone", "Selfie", any camera model.
+        FORBIDDEN in title: "A person standing", "Portrait of someone", a bare "Selfie" or \
+        "Portrait" with no descriptive content, any camera model. ("Selfie" is fine when paired \
+        with what the person is doing or where they are.)
 
         CONSTRAINT: Never guess identity, name, or specific age. Describe only what is observable.
 
@@ -320,7 +321,7 @@ enum ImageInsightPromptBuilder {
 
     private static func groupPrompt(evidence: String) -> String {
         """
-        This image contains multiple people as subjects.
+        This image has multiple detected faces and likely has multiple people as subjects.
 
         YOUR TASK: Describe the group — how many people, what they appear to be doing together, \
         and the setting. If OCR reveals venue/event signage, name it. Do not guess individual \
@@ -381,9 +382,9 @@ enum ImageInsightPromptBuilder {
         """
         This image has a strong single subject (object, animal, food, vehicle, etc.).
 
-        YOUR TASK: NAME the specific object using the highest-confidence classification. \
-        Describe its material, condition, and immediate context. Be specific — "vintage leather \
-        suitcase" not "an object."
+        YOUR TASK: Name the specific object using the highest-confidence non-generic classification. \
+        Describe only attributes supported by the evidence. Do not invent material, age, style, brand, \
+        condition, or use-history.
 
         TITLE: Name the object with a distinctive attribute. \
         Pattern: "[Object name] [distinctive attribute]"
@@ -398,8 +399,8 @@ enum ImageInsightPromptBuilder {
 
     private static func generalPrompt(evidence: String) -> String {
         """
-        Describe what this image shows. Use the signals below — actively name what you see. \
-        The limitations field is required.
+        Describe what this image shows. Use the strongest visual signals below and be explicit \
+        when the available evidence is weak. The limitations field is required.
 
         TITLE: Name the specific subject, scene, or activity. Never use a camera model as title. \
         A title like "iPhone 13 Pro Max Capture" is forbidden — describe the photograph's content.
@@ -416,11 +417,11 @@ enum ImageInsightPromptBuilder {
 
     private static let returnFormat = """
     Return:
-    - title: a short, specific title naming what THIS image shows
-    - summary: 1 to 2 sentences describing the visible content using primary evidence
+    - title: a short, specific title naming what THIS image shows; no generic photo/image wording
+    - summary: 1 to 2 sentences describing visible content first, using primary evidence
     - likelyContent: what is in the image, grounded in primary evidence. If sparse, say so plainly.
-    - usefulDetails: up to 4 short bullets; lead with content, include EXIF only when informative
-    - tags: up to 6 short content-focused tags from evidence; avoid camera-model tags
+    - usefulDetails: up to 4 short bullets; lead with content, avoid repeating camera models
+    - tags: up to 6 short content-focused tags from evidence; no camera, lens, or file-name tags
     - limitations: required — what this insight cannot determine from local signals
     """
 
@@ -443,20 +444,236 @@ enum ImageInsightPromptBuilder {
         let embeddedKeywords = input.keywords.isEmpty ? "None" : input.keywords.joined(separator: ", ")
 
         return """
-        File: \(input.fileName) (\(input.fileType), \(input.dimensions), \(input.fileSize))
-        \(dates.isEmpty ? "No file dates available." : dates)
-
-        ── PRIMARY EVIDENCE — On-device Apple Vision (USE every signal; name what you see) ──
+        ── PRIMARY EVIDENCE — On-device Apple Vision (weigh by confidence; name supported content) ──
         \(visual)
 
         ── SECONDARY EVIDENCE — Embedded file metadata (often user-authored; treat as hints) ──
         Description: \(input.metadataDescription ?? "None")
         Keywords: \(embeddedKeywords)
 
-        ── CONTEXT ONLY — Camera/EXIF/GPS (NEVER use as the title, summary, or main subject) ──
+        ── CONTEXT ONLY — File/Camera/EXIF/GPS (NEVER use as the title, summary, or main subject) ──
+        File name (not visual evidence): \(input.fileName)
+        File type: \(input.fileType)
+        Dimensions: \(input.dimensions)
+        File size: \(input.fileSize)
+        \(dates.isEmpty ? "No file dates available." : dates)
         \(camera)
         Color profile: \(input.colorProfile ?? "Not available")
         """
+    }
+}
+
+enum ImageInsightFallbackBuilder {
+    static func result(
+        for input: ImageInsightInput,
+        perception: ImagePerceptionResult,
+        type: ImageContentType
+    ) -> ImageInsightResult {
+        let labels = usableLabels(from: perception)
+        let nonPersonLabels = labels.filter { !personLikeLabels.contains($0) }
+
+        let title = title(for: type, perception: perception, subject: confidentSubject(from: perception))
+        let summary = summary(for: perception, labels: labels)
+        let details = details(for: input, perception: perception, labels: labels)
+        let tags = tags(for: type, labels: nonPersonLabels.isEmpty ? labels : nonPersonLabels)
+        let limitations = limitations(for: perception)
+
+        return ImageInsightResult(
+            title: title,
+            summary: summary,
+            likelyContent: likelyContent(for: perception, labels: labels),
+            usefulDetails: details,
+            tags: tags,
+            limitations: limitations
+        )
+    }
+
+    private static let personLikeLabels: Set<String> = [
+        "person", "people", "adult", "man", "woman", "boy", "girl", "child", "human"
+    ]
+
+    private static func title(
+        for type: ImageContentType,
+        perception: ImagePerceptionResult,
+        subject: String?
+    ) -> String {
+        switch type {
+        case .document:
+            if let firstLine = perception.recognizedText.first {
+                return "Document: \(clipped(firstLine, to: 50))"
+            }
+            return "Text-heavy image"
+        case .group:
+            return "\(perception.faceCount) people detected"
+        case .portrait:
+            return "Person detected in image"
+        case .landscape:
+            return subject.map { "\(capitalized($0)) outdoor scene" } ?? "Outdoor scene"
+        case .object:
+            return subject.map { "\(capitalized($0)) subject" } ?? "Foreground subject"
+        case .general:
+            return subject.map { "\(capitalized($0)) image" } ?? "Sparse visual evidence"
+        }
+    }
+
+    private static func summary(for perception: ImagePerceptionResult, labels: [String]) -> String {
+        var parts: [String] = []
+
+        if !labels.isEmpty {
+            parts.append("Apple Vision reported \(list(labels.prefix(4))) as the strongest visual categories.")
+        }
+
+        if perception.faceCount > 0 {
+            let noun = perception.faceCount == 1 ? "face" : "faces"
+            parts.append("It detected \(perception.faceCount) \(noun).")
+        }
+
+        if let firstText = perception.recognizedText.first {
+            parts.append("Readable text includes \"\(clipped(firstText, to: 60))\".")
+        }
+
+        if perception.salientObjectCount > 0 {
+            let noun = perception.salientObjectCount == 1 ? "foreground subject" : "foreground subjects"
+            parts.append("It found \(perception.salientObjectCount) \(noun).")
+        }
+
+        if parts.isEmpty {
+            return "On-device visual analysis did not return enough signals to describe specific content confidently."
+        }
+
+        return parts.joined(separator: " ")
+    }
+
+    private static func likelyContent(for perception: ImagePerceptionResult, labels: [String]) -> String {
+        if labels.isEmpty && perception.recognizedText.isEmpty && perception.faceCount == 0 {
+            return "Specific content is unclear from the available local signals."
+        }
+
+        var components: [String] = []
+        if !labels.isEmpty {
+            components.append("visual categories such as \(list(labels.prefix(3)))")
+        }
+        if perception.faceCount > 0 {
+            components.append("\(perception.faceCount) detected face\(perception.faceCount == 1 ? "" : "s")")
+        }
+        if !perception.recognizedText.isEmpty {
+            components.append("readable text")
+        }
+
+        return "Likely contains \(list(components))."
+    }
+
+    private static func details(
+        for input: ImageInsightInput,
+        perception: ImagePerceptionResult,
+        labels: [String]
+    ) -> [String] {
+        var details = ["\(input.fileType), \(input.dimensions), \(input.fileSize)"]
+
+        if !labels.isEmpty {
+            details.append("Top visual categories: \(list(labels.prefix(4)))")
+        }
+
+        if perception.faceCount > 0 {
+            details.append("Faces detected: \(perception.faceCount)")
+        }
+
+        if let firstText = perception.recognizedText.first {
+            details.append("Readable text: \(clipped(firstText, to: 70))")
+        }
+
+        if perception.salientObjectCount > 0 {
+            details.append("Foreground subjects detected: \(perception.salientObjectCount)")
+        }
+
+        return details
+    }
+
+    private static func tags(for type: ImageContentType, labels: [String]) -> [String] {
+        var output = type == .general ? [] : [type.rawValue]
+        output.append(contentsOf: labels.prefix(5))
+        return deduped(output)
+    }
+
+    private static func limitations(for perception: ImagePerceptionResult) -> [String] {
+        if perception.asSignals.isEmpty {
+            return [
+                "On-device Vision returned sparse signals, so this cannot identify specific content confidently."
+            ]
+        }
+
+        return [
+            "This cannot identify specific people, exact locations, or event names unless present in readable text."
+        ]
+    }
+
+    private static func usableLabels(from perception: ImagePerceptionResult) -> [String] {
+        perception.classifications
+            .filter { $0.confidence >= 0.2 }
+            .map { displayLabel($0.identifier) }
+            .filter { !$0.isEmpty }
+    }
+
+    /// The titling subject must clear a higher bar than the 0.2 floor used for summary/tags:
+    /// a sub-50%-confidence label should not be stated as a confident title (FALLBACK-2).
+    /// Returns nil when nothing qualifies, so the title hedges instead of guessing.
+    private static func confidentSubject(from perception: ImagePerceptionResult) -> String? {
+        perception.classifications
+            .filter { $0.confidence >= 0.5 }
+            .map { displayLabel($0.identifier) }
+            .first { !$0.isEmpty && !personLikeLabels.contains($0) }
+    }
+
+    private static func displayLabel(_ identifier: String) -> String {
+        identifier
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+
+    private static func capitalized(_ text: String) -> String {
+        guard let first = text.first else { return text }
+        return first.uppercased() + String(text.dropFirst())
+    }
+
+    private static func list<S: Sequence>(_ values: S) -> String where S.Element == String {
+        let items = Array(values)
+        switch items.count {
+        case 0:
+            return ""
+        case 1:
+            return items[0]
+        case 2:
+            return "\(items[0]) and \(items[1])"
+        default:
+            return "\(items.dropLast().joined(separator: ", ")), and \(items.last ?? "")"
+        }
+    }
+
+    private static func clipped(_ text: String, to limit: Int) -> String {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > limit else { return trimmed }
+        let end = trimmed.index(trimmed.startIndex, offsetBy: limit)
+        return String(trimmed[..<end]).trimmingCharacters(in: .whitespacesAndNewlines) + "..."
+    }
+
+    private static func deduped(_ values: [String]) -> [String] {
+        var seen = Set<String>()
+        var output: [String] = []
+
+        for value in values {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+
+            let key = trimmed.lowercased()
+            guard !seen.contains(key) else { continue }
+
+            seen.insert(key)
+            output.append(trimmed)
+        }
+
+        return output
     }
 }
 

--- a/StillView - Simple Image Viewer/Resources/whats-new.json
+++ b/StillView - Simple Image Viewer/Resources/whats-new.json
@@ -1,5 +1,5 @@
 {
-  "version": "4.0.0",
+  "version": "4.1.0",
   "releaseDate": "2026-05-17T00:00:00Z",
   "sections": [
     {

--- a/StillView - Simple Image Viewer/Services/AppleIntelligenceInsightsService.swift
+++ b/StillView - Simple Image Viewer/Services/AppleIntelligenceInsightsService.swift
@@ -86,13 +86,35 @@ struct AppleIntelligenceInsightsService: ImageInsightGenerating {
             }
 
             if case .failed(let reasons) = validation {
+                Logger.warning(
+                    "AI insight validation failed; retrying reasons=\(reasons.map(\.rawValue).joined(separator: ","))",
+                    context: "AIInsights"
+                )
                 let retryResult = try await generate(
                     input: enrichedInput,
                     type: contentType,
-                    profile: profile.retryProfile,
+                    profile: profile.retryProfile(for: reasons),
                     correctionHint: InsightOutputValidator.correctionHint(for: reasons)
                 )
-                return retryResult
+
+                let retryValidation = InsightOutputValidator.validate(retryResult, input: enrichedInput)
+                if case .passed = retryValidation {
+                    return retryResult
+                }
+
+                if case .failed(let retryReasons) = retryValidation {
+                    let retryReasonNames = retryReasons.map(\.rawValue).joined(separator: ",")
+                    Logger.warning(
+                        "AI insight retry validation failed; using grounded fallback reasons=\(retryReasonNames)",
+                        context: "AIInsights"
+                    )
+                }
+
+                return ImageInsightFallbackBuilder.result(
+                    for: enrichedInput,
+                    perception: perception,
+                    type: contentType
+                )
             }
 
             return result
@@ -243,24 +265,24 @@ private extension AppleIntelligenceInsightsService {
 }
 
 @available(macOS 26.0, *)
-@Generable(description: "A concise image insight describing the visible content of a local image, grounded in on-device Vision analysis. Camera and EXIF metadata are supplementary context only and must not drive the title or subject.")
+@Generable(description: "A concise image insight describing visible content from on-device Vision analysis. Camera and EXIF metadata are supplementary context only and must not drive the title or subject.")
 private struct GeneratedImageInsight {
-    @Guide(description: "A short title naming what the image shows — its subject, scene, or activity. Never use the camera model, lens, or shooting settings as the title. A title like 'iPhone 13 Pro Max Capture' is forbidden; describe the photograph's content instead.")
+    @Guide(description: "A short title naming what the image shows: subject, scene, or activity. Never use camera model, lens, shooting settings, file name, or prompt examples as the title.")
     let title: String
 
-    @Guide(description: "One or two sentences describing the visible content of the image, drawn from the on-device Vision signals (scene categories, recognized text, faces). Do not describe the camera or shooting settings.")
+    @Guide(description: "One or two sentences describing visible content from on-device Vision signals: scene categories, recognized text, and faces. Do not describe the camera or shooting settings.")
     let summary: String
 
     @Guide(description: "A cautious description of what the image likely depicts, based on the primary visual signals. If the visual signals are sparse or empty, say so plainly rather than guessing from EXIF.")
     let likelyContent: String
 
-    @Guide(description: "Up to 4 short bullet points of useful details about the image. Lead with content; include camera or EXIF only when genuinely helpful (e.g. capture date for a memory). Never repeat the camera model as a detail.")
+    @Guide(description: "Up to 4 short bullet points of useful details about the image. Lead with content. Include camera or EXIF only when genuinely helpful. Never repeat the camera model as a detail.")
     let usefulDetails: [String]
 
-    @Guide(description: "Up to 6 short content-focused tags describing the image (e.g. 'group photo', 'indoor', 'sports venue', 'celebration'). Avoid camera-model or EXIF-only tags.")
+    @Guide(description: "Up to 6 short content-focused tags describing the image. Avoid camera-model, file-name, prompt-example, or EXIF-only tags.")
     let tags: [String]
 
-    @Guide(description: "Required. What this insight cannot determine from local signals (e.g. 'specific names of people', 'precise location', 'event identity').")
+    @Guide(description: "Required. What this insight cannot determine from local signals, without adding unsupported specifics.")
     let limitations: [String]
 
     var result: ImageInsightResult {

--- a/StillView - Simple Image Viewer/Services/ImageContentTypeClassifier.swift
+++ b/StillView - Simple Image Viewer/Services/ImageContentTypeClassifier.swift
@@ -4,11 +4,26 @@ enum ImageContentTypeClassifier {
     private static let outdoorKeywords: Set<String> = [
         "sky", "tree", "mountain", "beach", "ocean", "lake", "river",
         "field", "forest", "sunset", "sunrise", "cloud", "snow",
-        "desert", "garden", "park"
+        "desert", "garden", "park", "landscape", "coast", "shore",
+        "waterfall", "water", "trail", "valley", "canyon", "cityscape"
+    ]
+
+    private static let documentKeywords: Set<String> = [
+        "text", "document", "screenshot", "screen", "paper", "page",
+        "receipt", "menu", "book", "whiteboard", "presentation", "slide",
+        "chart", "graph", "form", "table", "webpage", "website",
+        "card", "license", "passport", "id", "badge"
+    ]
+
+    private static let nonObjectKeywords: Set<String> = [
+        "indoor", "outdoor", "inside", "outside", "room", "building",
+        "architecture", "person", "people", "adult", "man", "woman",
+        "portrait", "group", "sky", "text", "document", "screenshot",
+        "screen", "landscape", "nature"
     ]
 
     static func classify(_ perception: ImagePerceptionResult) -> ImageContentType {
-        if perception.recognizedText.count >= 15 {
+        if hasDocumentLikeText(perception) {
             return .document
         }
 
@@ -24,18 +39,69 @@ enum ImageContentTypeClassifier {
             return .landscape
         }
 
+        // Horizonless outdoor scenes (forest, dune, top-down snow, occluded waterline) with no
+        // distinct foreground subject are still landscapes. The salientObjectCount == 0 gate is
+        // the discriminator that keeps object-in-outdoor photos (boat on water, dog in a park)
+        // in .object rather than over-routing them here (ROUTE-1).
+        if perception.salientObjectCount == 0 && hasStrongOutdoorClassification(perception) {
+            return .landscape
+        }
+
         if perception.salientObjectCount <= 2,
-           let top = perception.classifications.first,
-           top.confidence > 0.7 {
+           perception.classifications.contains(where: isStrongObjectClassification) {
             return .object
         }
 
         return .general
     }
 
+    private static func hasDocumentLikeText(_ perception: ImagePerceptionResult) -> Bool {
+        let textLineCount = perception.recognizedText.count
+        let text = perception.recognizedText.joined(separator: " ")
+        let wordCount = text
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { $0.count >= 2 }
+            .count
+
+        if textLineCount >= 8 || wordCount >= 24 || text.count >= 140 {
+            return true
+        }
+
+        return textLineCount >= 3 && hasDocumentClassification(perception)
+    }
+
+    private static func hasDocumentClassification(_ perception: ImagePerceptionResult) -> Bool {
+        perception.classifications.contains { classification in
+            classification.confidence > 0.25 && containsKeyword(classification.identifier, in: documentKeywords)
+        }
+    }
+
     private static func hasOutdoorClassification(_ perception: ImagePerceptionResult) -> Bool {
         perception.classifications.contains { classification in
-            classification.confidence > 0.3 && outdoorKeywords.contains(classification.identifier)
+            classification.confidence > 0.3 && containsKeyword(classification.identifier, in: outdoorKeywords)
+        }
+    }
+
+    /// Higher-confidence outdoor check (≥0.5) used for the horizonless-landscape branch, where
+    /// there is no horizon corroborating the scene — so the classification must be stronger.
+    private static func hasStrongOutdoorClassification(_ perception: ImagePerceptionResult) -> Bool {
+        perception.classifications.contains { classification in
+            classification.confidence >= 0.5 && containsKeyword(classification.identifier, in: outdoorKeywords)
+        }
+    }
+
+    private static func isStrongObjectClassification(_ classification: ImagePerceptionResult.Classification) -> Bool {
+        classification.confidence > 0.7 && !containsKeyword(classification.identifier, in: nonObjectKeywords)
+    }
+
+    private static func containsKeyword(_ identifier: String, in keywords: Set<String>) -> Bool {
+        let normalized = identifier
+            .replacingOccurrences(of: "_", with: " ")
+            .replacingOccurrences(of: "-", with: " ")
+            .lowercased()
+
+        return keywords.contains { keyword in
+            normalized == keyword || normalized.contains(" \(keyword)") || normalized.contains("\(keyword) ")
         }
     }
 }
@@ -47,10 +113,21 @@ struct GenerationProfile: Sendable, Equatable {
 
     var retryProfile: GenerationProfile {
         GenerationProfile(
-            temperature: temperature + 0.15,
-            topK: topK,
+            temperature: max(0.1, temperature - 0.1),
+            topK: max(1, min(topK, 2)),
             maxTokens: maxTokens
         )
+    }
+
+    /// Under-specification failures (empty/generic output) are made WORSE by the default
+    /// tighten-on-retry, which pushes the model toward the same conservative argmax that
+    /// produced the bare answer. Hold sampling steady for those and let the correctionHint do
+    /// the work; for any hallucination/leakage failure, keep tightening. A mixed set defaults
+    /// to the safe (tightened) path (PROFILE-1).
+    func retryProfile(for failures: [ValidationFailure]) -> GenerationProfile {
+        let underSpecification: Set<ValidationFailure> = [.emptyDespiteSignals, .genericFillerTitle]
+        let allUnderSpecified = !failures.isEmpty && failures.allSatisfy { underSpecification.contains($0) }
+        return allUnderSpecified ? self : retryProfile
     }
 
     static func profile(for type: ImageContentType) -> GenerationProfile {

--- a/StillView - Simple Image Viewer/Services/ImagePerceptionService.swift
+++ b/StillView - Simple Image Viewer/Services/ImagePerceptionService.swift
@@ -71,18 +71,20 @@ struct ImagePerceptionResult: Equatable, Sendable {
 /// case-insensitively and drop tokens that are too short or mostly non-alphabetic —
 /// this stops the FM from distrusting the entire OCR field because of a few garbled
 /// fragments.
-private enum OCRCleaner {
+enum OCRCleaner {
     static func clean(_ raw: [String]) -> [String] {
         var seen = Set<String>()
         var output: [String] = []
 
         for token in raw {
             let trimmed = token.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard trimmed.count >= 3 else { continue }
+            // A single CJK character (出, 湯, …) is valid standalone signage; the 2-character
+            // floor would otherwise discard it even though OCR is configured for ja/zh/ko.
+            guard trimmed.count >= 2 || isStandaloneCJK(trimmed) else { continue }
 
-            let letterCount = trimmed.unicodeScalars.filter { CharacterSet.letters.contains($0) }.count
-            let alphaRatio = Double(letterCount) / Double(trimmed.count)
-            guard alphaRatio >= 0.5 else { continue }
+            let semanticCount = trimmed.unicodeScalars.filter { CharacterSet.alphanumerics.contains($0) }.count
+            let semanticRatio = Double(semanticCount) / Double(trimmed.count)
+            guard semanticCount >= 2 || isStandaloneCJK(trimmed), semanticRatio >= 0.5 else { continue }
 
             let key = trimmed.lowercased()
             guard !seen.contains(key) else { continue }
@@ -92,6 +94,17 @@ private enum OCRCleaner {
 
         return output
     }
+
+    /// True for a single CJK character (Han / Kana / Hangul) — a valid one-character signage
+    /// token that the generic multi-character floors would otherwise discard (PERCEPT-3).
+    private static func isStandaloneCJK(_ token: String) -> Bool {
+        guard token.count == 1, let scalar = token.unicodeScalars.first else { return false }
+        let value = scalar.value
+        return (0x4E00...0x9FFF).contains(value)   // CJK Unified Ideographs
+            || (0x3400...0x4DBF).contains(value)   // CJK Extension A
+            || (0x3040...0x30FF).contains(value)   // Hiragana + Katakana
+            || (0xAC00...0xD7A3).contains(value)   // Hangul syllables
+    }
 }
 
 /// Runs a focused set of on-device Vision requests against a local image and returns
@@ -99,6 +112,13 @@ private enum OCRCleaner {
 /// Runs entirely on-device — Apple Vision ships with macOS; no network calls, no remote model fetches.
 struct ImagePerceptionService: Sendable {
     static let shared = ImagePerceptionService()
+
+    /// Whether a detected face should be counted as a real foreground subject: it qualifies
+    /// when it occupies a reasonable area OR is high-confidence. `faceCount` drives prompt
+    /// routing (portrait vs group), so this predicate is kept pure and unit-tested (PERCEPT-2).
+    static func shouldCountFace(area: Double, confidence: Float) -> Bool {
+        area >= 0.003 || confidence >= 0.7
+    }
 
     /// Analyze the image at `url` and return on-device perception results.
     /// Returns `.empty` if the image cannot be decoded or if every request fails.
@@ -179,18 +199,19 @@ struct ImagePerceptionService: Sendable {
         let recognizedText = OCRCleaner.clean(rawText)
 
         // Two-pronged face filter so we count real foreground subjects, not background
-        // blurs or false positives:
-        //   - Area ≥ 0.3% catches all reasonable foreground faces (even a 5-person group
-        //     photo where each face occupies ~0.8-1% of the frame).
-        //   - Confidence ≥ 0.7 rejects false positives that happen to be large (e.g. a
-        //     face-shaped pattern in a poster, decoration, or reflection).
+        // blurs (see `shouldCountFace`):
+        //   - Area ≥ 0.3% catches reasonable foreground faces (even a 5-person group photo
+        //     where each face occupies ~0.8-1% of the frame).
+        //   - Confidence ≥ 0.7 RESCUES small but high-confidence faces below the area floor
+        //     (a distant but real face). Because the two arms are OR'd, this can only ADD
+        //     matches — it cannot reject a large detection.
         // Either condition is enough to qualify; together they balance the rose-photo case
         // (tiny background figures → 0 faces) with the group-photo case (5 real subjects
         // → 5 faces).
         let faceCount = (faceDetection.results ?? [])
             .filter { observation in
                 let area = observation.boundingBox.width * observation.boundingBox.height
-                return area >= 0.003 || observation.confidence >= 0.7
+                return shouldCountFace(area: Double(area), confidence: observation.confidence)
             }
             .count
         let salientObjectCount = saliency.results?.first?.salientObjects?.count ?? 0

--- a/StillView - Simple Image Viewer/Services/InsightEvalHarness.swift
+++ b/StillView - Simple Image Viewer/Services/InsightEvalHarness.swift
@@ -1,0 +1,209 @@
+#if DEBUG
+import Foundation
+import AppKit
+
+/// DEBUG-only manual evaluation harness for AI Insights. Runs the real on-device pipeline
+/// (perception → classify → generate → validate) over a folder of images and writes a Markdown
+/// report you can eyeball. Triggered from the Debug menu ("Run AI Insights Eval…").
+///
+/// It runs in the app process so FoundationModels is available and everything links. The app's
+/// sandbox is `files.user-selected.read-only`, so the report is written to the app container's
+/// temporary directory and revealed in Finder rather than saved to a user-chosen location.
+/// Only top-level images in the chosen folder are evaluated (non-recursive); keep the eval set flat.
+enum InsightEvalHarness {
+
+    private static let supportedExtensions: Set<String> = [
+        "jpg", "jpeg", "png", "heic", "heif", "gif", "tiff", "tif", "bmp", "webp"
+    ]
+
+    /// One image's evaluation outcome.
+    private struct Record {
+        let fileName: String
+        let route: ImageContentType
+        let perceptionSignals: [String]
+        let validation: InsightValidation?
+        let result: ImageInsightResult?
+        let error: String?
+    }
+
+    private enum Outcome {
+        case report(url: URL, imageCount: Int)
+        case failure(String)
+    }
+
+    // MARK: - Entry point (Debug menu command)
+
+    @MainActor
+    static func presentAndRun() {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.allowsMultipleSelection = false
+        panel.prompt = "Run Eval"
+        panel.message = "Choose a folder of images to evaluate AI Insights on."
+
+        guard panel.runModal() == .OK, let folder = panel.url else { return }
+
+        let availability = AppleIntelligenceInsightsService.shared.availability()
+        guard availability.isAvailable else {
+            presentAlert(title: "AI Insights Unavailable", message: availability.message)
+            return
+        }
+
+        Task.detached {
+            let outcome = await run(folder: folder)
+            await MainActor.run { present(outcome) }
+        }
+    }
+
+    // MARK: - Run
+
+    private static func run(folder: URL) async -> Outcome {
+        let scoped = folder.startAccessingSecurityScopedResource()
+        defer { if scoped { folder.stopAccessingSecurityScopedResource() } }
+
+        let imageURLs = supportedImageURLs(in: folder)
+        guard !imageURLs.isEmpty else {
+            return .failure("No supported images found in \(folder.path).")
+        }
+
+        let service = AppleIntelligenceInsightsService.shared
+        var sections: [String] = []
+        // Sequential on purpose: FoundationModels rejects concurrent requests. Print per-image
+        // progress (DEBUG console only) so a multi-minute run is visibly working, not hung.
+        for (index, imageURL) in imageURLs.enumerated() {
+            // Intentional print, not os.log: DEBUG-only dev progress that must NOT push file
+            // names into the unified log (the codebase's no-filename-logging privacy rule).
+            // swiftlint:disable:next no_print
+            print("📸 Insight eval \(index + 1)/\(imageURLs.count): \(imageURL.lastPathComponent)")
+            sections.append(await evaluate(imageURL: imageURL, service: service))
+        }
+
+        let report = reportHeader(folder: folder, count: imageURLs.count)
+            + sections.joined(separator: "\n\n") + "\n"
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("insight-eval-report.md")
+        do {
+            try report.write(to: outputURL, atomically: true, encoding: .utf8)
+            return .report(url: outputURL, imageCount: imageURLs.count)
+        } catch {
+            return .failure("Could not write report: \(error.localizedDescription)")
+        }
+    }
+
+    /// Runs the production path for one image. Perception is run here for the displayed signals
+    /// and route; `generateInsight` re-runs it internally (minor redundancy) so the insight comes
+    /// from the exact production path. Per-image errors are captured, not thrown.
+    private static func evaluate(imageURL: URL, service: AppleIntelligenceInsightsService) async -> String {
+        let perception = await ImagePerceptionService.shared.analyze(url: imageURL)
+        let route = ImageContentTypeClassifier.classify(perception)
+        let fileName = imageURL.lastPathComponent
+
+        do {
+            let imageFile = try ImageFile(url: imageURL)
+            let input = service.makeInput(for: imageFile)
+            let result = try await service.generateInsight(for: input)
+            let validation = InsightOutputValidator.validate(result, input: input)
+            return markdownSection(Record(
+                fileName: fileName, route: route, perceptionSignals: perception.asSignals,
+                validation: validation, result: result, error: nil
+            ))
+        } catch {
+            return markdownSection(Record(
+                fileName: fileName, route: route, perceptionSignals: perception.asSignals,
+                validation: nil, result: nil, error: error.localizedDescription
+            ))
+        }
+    }
+
+    // MARK: - Formatting
+
+    private static func supportedImageURLs(in folder: URL) -> [URL] {
+        let contents = (try? FileManager.default.contentsOfDirectory(
+            at: folder, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])) ?? []
+        return contents
+            .filter { supportedExtensions.contains($0.pathExtension.lowercased()) }
+            .sorted { $0.lastPathComponent.localizedStandardCompare($1.lastPathComponent) == .orderedAscending }
+    }
+
+    private static func reportHeader(folder: URL, count: Int) -> String {
+        """
+        # AI Insights Eval Report
+
+        - Folder: \(folder.path)
+        - Images: \(count)
+
+        ---
+
+        """
+    }
+
+    private static func markdownSection(_ record: Record) -> String {
+        var lines = ["## \(record.fileName)", "- Route: \(record.route.rawValue)"]
+
+        if let error = record.error {
+            lines.append("- **ERROR:** \(error)")
+            return lines.joined(separator: "\n")
+        }
+
+        if let validation = record.validation {
+            switch validation {
+            case .passed:
+                lines.append("- Validator: PASSED")
+            case .failed(let reasons):
+                lines.append("- Validator: FAILED [\(reasons.map(\.rawValue).joined(separator: ", "))]")
+            }
+        }
+
+        if record.perceptionSignals.isEmpty {
+            lines.append("- Perception: (no signals)")
+        } else {
+            lines.append("- Perception:")
+            lines.append(contentsOf: record.perceptionSignals.map { "  - \($0)" })
+        }
+
+        if let result = record.result {
+            lines.append("- Title: \(result.title)")
+            lines.append("- Summary: \(result.summary)")
+            lines.append("- Likely content: \(result.likelyContent)")
+            if !result.usefulDetails.isEmpty {
+                lines.append("- Useful details:")
+                lines.append(contentsOf: result.usefulDetails.map { "  - \($0)" })
+            }
+            lines.append("- Tags: \(result.tags.joined(separator: ", "))")
+            if !result.limitations.isEmpty {
+                lines.append("- Limitations:")
+                lines.append(contentsOf: result.limitations.map { "  - \($0)" })
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    // MARK: - UI helpers
+
+    @MainActor
+    private static func present(_ outcome: Outcome) {
+        switch outcome {
+        case .report(let url, let imageCount):
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+            presentAlert(
+                title: "Eval Complete",
+                message: "Evaluated \(imageCount) image(s).\nReport: \(url.path)"
+            )
+        case .failure(let message):
+            presentAlert(title: "Eval Failed", message: message)
+        }
+    }
+
+    @MainActor
+    private static func presentAlert(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}
+#endif

--- a/StillView - Simple Image Viewer/Services/InsightOutputValidator.swift
+++ b/StillView - Simple Image Viewer/Services/InsightOutputValidator.swift
@@ -7,10 +7,12 @@ enum InsightValidation: Sendable, Equatable {
 
 enum ValidationFailure: String, Sendable, CaseIterable {
     case cameraModelTitle
+    case cameraModelLeakage
     case genericFillerTitle
     case emptyDespiteSignals
     case exifDrivenContent
     case rawOCRDump
+    case fileNameTitle
 }
 
 enum InsightOutputValidator {
@@ -21,6 +23,10 @@ enum InsightOutputValidator {
             failures.append(.cameraModelTitle)
         }
 
+        if hasCameraModelLeakage(result, cameraSignals: input.cameraSignals) {
+            failures.append(.cameraModelLeakage)
+        }
+
         if hasGenericFillerTitle(result.title) {
             failures.append(.genericFillerTitle)
         }
@@ -29,12 +35,16 @@ enum InsightOutputValidator {
             failures.append(.emptyDespiteSignals)
         }
 
-        if hasExifDrivenContent(result.summary) {
+        if hasExifDrivenContent(result) {
             failures.append(.exifDrivenContent)
         }
 
         if hasRawOCRDump(result.title, input: input) {
             failures.append(.rawOCRDump)
+        }
+
+        if hasFileNameTitle(result.title, input: input) {
+            failures.append(.fileNameTitle)
         }
 
         return failures.isEmpty ? .passed : .failed(reasons: failures)
@@ -45,14 +55,18 @@ enum InsightOutputValidator {
             switch failure {
             case .cameraModelTitle:
                 return "Do NOT use the camera model in the title. Name what the image SHOWS instead."
+            case .cameraModelLeakage:
+                return "Remove camera models from summary, details, and tags. Camera metadata is context only."
             case .genericFillerTitle:
                 return "Be specific in the title. Name the subject, scene, or activity directly."
             case .emptyDespiteSignals:
-                return "Vision detected signals — use them. The title and summary must reference the specific classifications and text found."
+                return "Vision detected signals — use them. Reference the specific classifications and text found."
             case .exifDrivenContent:
                 return "The summary must describe image CONTENT, not camera settings. Lead with what is visible."
             case .rawOCRDump:
                 return "Synthesize the text into a meaningful description rather than copying it verbatim."
+            case .fileNameTitle:
+                return "Do NOT use the file name as the title. Use only visual evidence to name the image."
             }
         }
         return hints.joined(separator: " ")
@@ -64,51 +78,169 @@ enum InsightOutputValidator {
         "a photograph of",
         "an image of",
         "a photo showing",
+        "a photo of",
         "a picture of",
         "this is a",
         "an image showing",
-        "a photograph showing"
+        "a photograph showing",
+        "photo of",
+        "image of",
+        "picture of"
     ]
 
-    private static let exifPatterns = ["f/", "iso ", "focal length", "mm lens"]
+    private static let genericExactTitles = [
+        "local image insight",
+        "image insight",
+        "generated insight",
+        "photo",
+        "image",
+        "picture",
+        "untitled image",
+        "selfie",
+        "portrait"
+    ]
+
+    // Type-specific FORBIDDEN-title phrases from the per-type prompts, mirrored here so a
+    // phrase the prompt forbids cannot silently bypass the validator (CONSIST-2).
+    private static let genericFillerPrefixes = [
+        "a person standing",
+        "portrait of someone",
+        "a group of people",
+        "several individuals",
+        "text on a screen",
+        "a document showing",
+        "a beautiful landscape",
+        "a scenic view of",
+        "nature scene",
+        "an object on a surface",
+        "a photo of an item"
+    ]
+
+    // The one forbidden example still present in the prompt scaffold. Matched independently of
+    // camera metadata so a camera-less image cannot ship the parroted title (CONSIST-5).
+    private static let scaffoldForbiddenTitlePhrases = [
+        "iphone 13 pro max capture"
+    ]
+
+    private static let exifPatterns = [
+        "f/",
+        "iso ",
+        "focal length",
+        "mm lens",
+        "shutter speed",
+        "aperture",
+        "gps",
+        "latitude",
+        "longitude",
+        "coordinates",
+        "captured with",
+        "shot on",
+        "camera settings"
+    ]
 
     private static func hasCameraModelInTitle(_ title: String, cameraSignals: [String]) -> Bool {
-        let lowercaseTitle = title.lowercased()
+        hasCameraModel(in: title, cameraSignals: cameraSignals)
+    }
+
+    private static func hasCameraModelLeakage(_ result: ImageInsightResult, cameraSignals: [String]) -> Bool {
+        let fields = [result.summary, result.likelyContent] + result.usefulDetails + result.tags
+        return fields.contains { hasCameraModel(in: $0, cameraSignals: cameraSignals) }
+    }
+
+    private static func hasCameraModel(in text: String, cameraSignals: [String]) -> Bool {
+        let lowercaseText = text.lowercased()
 
         for signal in cameraSignals {
             guard signal.hasPrefix("Camera:") else { continue }
             let cameraName = String(signal.dropFirst("Camera:".count)).trimmingCharacters(in: .whitespaces)
-            let tokens = cameraName.split(separator: " ").map { String($0).lowercased() }
-            let significantTokens = tokens.filter { $0.count >= 3 }
-            let matchCount = significantTokens.filter { lowercaseTitle.contains($0) }.count
+            let significantTokens = normalizedWords(cameraName).filter(isSignificantCameraToken)
+            let matchCount = significantTokens.filter { lowercaseText.contains($0) }.count
             if matchCount >= 2 {
+                return true
+            }
+            // Single-token make/model (e.g. "DJI", "Leica", "GoPro"): the ≥2 rule never fires,
+            // so flag when the lone token is model-like (has a digit, or isn't a generic brand
+            // word) — keeping homonyms like "Apple orchard" or "Canon in D" from tripping it.
+            if significantTokens.count == 1,
+               matchCount == 1,
+               let token = significantTokens.first,
+               isModelLikeToken(token) {
                 return true
             }
         }
         return false
     }
 
+    // Single-token camera makes that are also ordinary subject words (a store, a campus, a
+    // fruit). A bare make matching the title is treated as content, not leakage — distinctive
+    // model names ("DJI", "Leica", "RX100") still fall through to the model-like check.
+    private static let cameraBrandStopSet: Set<String> = [
+        "apple", "canon", "sony", "nikon", "fujifilm", "camera",
+        "google", "samsung", "motorola", "oneplus", "huawei", "xiaomi"
+    ]
+
+    private static func isModelLikeToken(_ token: String) -> Bool {
+        token.contains(where: \.isNumber) || !cameraBrandStopSet.contains(token)
+    }
+
     private static func hasGenericFillerTitle(_ title: String) -> Bool {
-        let lowercaseTitle = title.lowercased()
-        return genericPrefixes.contains { lowercaseTitle.hasPrefix($0) }
+        let lowercaseTitle = title.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+        return genericExactTitles.contains(lowercaseTitle)
+            || genericPrefixes.contains { lowercaseTitle.hasPrefix($0) }
+            || genericFillerPrefixes.contains { lowercaseTitle.hasPrefix($0) }
+            || scaffoldForbiddenTitlePhrases.contains { lowercaseTitle.contains($0) }
     }
 
     private static func hasEmptyDespiteSignals(_ result: ImageInsightResult, input: ImageInsightInput) -> Bool {
-        let isDefaultTitle = result.title == "Local Image Insight"
-        let hasSignals = !input.visualSignals.isEmpty
-        return isDefaultTitle && hasSignals
+        guard !input.visualSignals.isEmpty else { return false }
+
+        return result.title == "Local Image Insight"
+            || result.summary == "Generated from local file metadata and available system signals."
+            || result.likelyContent == "Not enough local signals to identify specific content."
     }
 
-    private static func hasExifDrivenContent(_ summary: String) -> Bool {
-        let lowercaseSummary = summary.lowercased()
-        let exifHits = exifPatterns.filter { lowercaseSummary.contains($0) }.count
+    private static func hasExifDrivenContent(_ result: ImageInsightResult) -> Bool {
+        let primaryText = ([result.title, result.summary, result.likelyContent] + result.tags)
+            .joined(separator: " ")
+            .lowercased()
+        let exifHits = exifPatterns.filter { primaryText.contains($0) }.count
         return exifHits >= 2
     }
 
     private static func hasRawOCRDump(_ title: String, input: ImageInsightInput) -> Bool {
         let ocrLines = extractOCRLines(from: input.visualSignals)
-        let uppercaseTitle = title.uppercased()
-        return ocrLines.contains { $0.uppercased() == uppercaseTitle }
+        let titleWords = normalizedWords(title)
+        guard titleWords.count >= 3 else { return false }
+
+        let ocrWords = Set(normalizedWords(ocrLines.joined(separator: " ")))
+        guard !ocrWords.isEmpty else { return false }
+
+        // RULE 1 mandates naming a short sign after its own text, so a title that matches a
+        // tiny OCR corpus is correct, not a dump. Only treat high overlap as a raw dump when
+        // the OCR corpus is substantially larger than a single short phrase.
+        guard ocrWords.count >= 6 else { return false }
+
+        let overlapCount = titleWords.filter { ocrWords.contains($0) }.count
+        let overlapRatio = Double(overlapCount) / Double(titleWords.count)
+        return overlapRatio >= 0.85
+    }
+
+    private static func hasFileNameTitle(_ title: String, input: ImageInsightInput) -> Bool {
+        let stem = URL(fileURLWithPath: input.fileName).deletingPathExtension().lastPathComponent
+        let titleWords = Set(normalizedWords(title))
+        let fileWords = normalizedWords(stem)
+
+        guard fileWords.count >= 2 || (fileWords.first?.count ?? 0) >= 4 else {
+            return false
+        }
+        guard !fileWords.isEmpty else { return false }
+
+        // Flag when the title echoes most of the file-name stem with no visual support. This
+        // catches the extra-word / reordered cases that exact word-set equality used to miss,
+        // while file-name words the image genuinely shows (present in the evidence) don't count.
+        let evidence = evidenceText(from: input)
+        let echoed = fileWords.filter { titleWords.contains($0) && !evidence.contains($0) }
+        return Double(echoed.count) / Double(fileWords.count) >= 0.66
     }
 
     private static func extractOCRLines(from visualSignals: [String]) -> [String] {
@@ -124,5 +256,32 @@ enum InsightOutputValidator {
             }
         }
         return []
+    }
+
+    private static func evidenceText(from input: ImageInsightInput) -> String {
+        (
+            input.visualSignals
+                + [input.metadataDescription ?? ""]
+                + input.keywords
+        )
+        .joined(separator: " ")
+        .lowercased()
+    }
+
+    private static func normalizedWords(_ text: String) -> [String] {
+        text.lowercased()
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func isSignificantCameraToken(_ token: String) -> Bool {
+        if token.count >= 3 {
+            return true
+        }
+
+        let hasLetter = token.unicodeScalars.contains { CharacterSet.letters.contains($0) }
+        let hasNumber = token.unicodeScalars.contains { CharacterSet.decimalDigits.contains($0) }
+        return token.count >= 2 && hasLetter && hasNumber
     }
 }

--- a/insight-quality-report.md
+++ b/insight-quality-report.md
@@ -1,0 +1,301 @@
+# AI Insights — Generation-System Quality Review
+
+## Scope
+
+This reviews the **generation system** that shapes AI Insights — the prompt contract (`systemInstruction` + 6 type-specific prompts + 3 ranked evidence buckets + `returnFormat`), the perception signal rendering, the classifier routing thresholds, the `@Generable`/`@Guide` constraints, and the `InsightOutputValidator` gate — **not live model outputs**. FoundationModels runs on-device only, so model behavior cannot be exercised here; every finding is grounded in code that was read and traced, with verified `file:line`. Findings split into three actionability tiers: (1) **testable-correctness** fixes that are safe to apply and verify via `xcodebuild test`; (2) **prompt/contract** changes that alter shipping model behavior and need human approval; (3) **tuning** dials that are reversible experiments.
+
+> All severities below are the **verification-corrected** values. The review pass downgraded six findings from `high` (the original triage) after tracing blast radius; those deltas are shown inline. **VALID-1 is the only item that remains `high`.** Several proposed diffs in the source findings were traced as *broken* (they regress their own tests); the fixes below use the corrected implementations from the verification pass.
+
+---
+
+## 2. Quick wins — testable-correctness fixes
+
+Safe to apply and verify with `xcodebuild test`. Ordered by corrected severity.
+
+| # | Sev | File:line | Defect (1-line) | Fix | Test |
+|---|-----|-----------|-----------------|-----|------|
+| VALID-1 (+CONSIST-3) | **high** | `InsightOutputValidator.swift:123-138, 211-224` | `hasPromptScaffoldLeakage` guards a removed `suitcase`/`leather` prompt example and now false-positives correct output when Vision emits a synonym (`luggage`/`bag`) | Delete the check entirely (see below) | New `test_legitimateLeatherSuitcasePhotoPasses`; delete 2 over-fit tests |
+| FALLBACK-1 | medium ↓ | `ImageInsightCore.swift:500-501` | `.document` fallback's `"Text-heavy image"` branch is unreachable; every document fallback emits the constant `"Readable text in image"` | Lead title with cleaned first OCR line via `clipped()` | New `test_documentFallbackTitleIncludesOCRText` |
+| FALLBACK-2 | medium | `ImageInsightCore.swift:606-611, 472` | Fallback promotes a ≥0.2-confidence label to a confident title (`"Blur outdoor scene"`) with no hedge, defeating the prompt's hedge-when-weak rule | Gate the *titling* subject at ≥0.5; keep 0.2 list for summary/tags | New `test_fallbackTitleHedgesWhenTopLabelIsLowConfidence` (type `.general`) |
+| PERCEPT-2 | medium ↓ | `ImagePerceptionService.swift:190-195` | Routing-critical face-count predicate (`area ≥ 0.003 ‖ conf ≥ 0.7`) is trapped in a `private` Vision closure with zero test coverage; broke once already (commit `1e423ec`) | Extract `static func shouldCountFace(area:confidence:)`, call it from the filter | New `ImagePerceptionServiceTests.test_shouldCountFace_*` (3 cases) |
+| VALID-2 | medium | `InsightOutputValidator.swift:84-95, 164-168` | `genericPrefixes` has `"a photo showing"` but not `"a photo of"` — `"A photo of a sunset"` slips through (`hasPrefix` asymmetry) | Add `"a photo of"` to `genericPrefixes` | New: assert `"A photo of a sunset"` → `.genericFillerTitle` |
+| VALID-3 | medium | `InsightOutputValidator.swift:149-162` | `hasCameraModel` needs ≥2 significant tokens; single-token makes (`Camera: DJI`/`GoPro`, or any file missing the Model tag) never fire | Require 1 match when `significantTokens.count == 1`, keep ≥2 otherwise | New: `"DJI aerial shot"` + `["Camera: DJI"]` → `.cameraModelTitle`; assert no FP on `"A red apple…"` + `["Camera: Apple iPhone 15"]` |
+| CONSIST-4 | medium | `InsightOutputValidator.swift:149-162` | Short camera models (`RX100`, bare `iPhone`) defeat the ≥2 gate even though the prompt forbids "any camera model" in the title | Same single-token relaxation as VALID-3, **plus** require the lone token be model-like (contains a digit OR not in a brand stop-set) so `"Apple orchard"` doesn't trip | New `test_singleDistinctiveCameraTokenInTitleFails`; keep `test_cameraModelNotInTitlePasses` |
+| CONSIST-2 (+CONSIST-6) | medium ↓ | `InsightOutputValidator.swift:84-105, 164-168` vs `ImageInsightCore.swift:310,331,351,371,390` | 12 type-specific FORBIDDEN-title phrases (`"A beautiful landscape"`, `"Nature scene"`, `"Portrait of someone"`, …) are invisible to the validator — pure silent drift | Add a generic-filler phrase list checked by **prefix/word-boundary** (not unbounded `.contains`); add bare `"selfie"`/`"portrait"` to `genericExactTitles` | New `test_typeSpecificForbiddenTitlesFailValidation` iterating the 12 |
+| CONSIST-5 | medium | `InsightOutputValidator.swift:140-162` vs `ImageInsightCore.swift:271,404` | The headline forbidden example `"iPhone 13 Pro Max Capture"` is only caught when camera EXIF is present; a camera-less PNG/screenshot can ship the parroted title | Add a 1-element scaffold-forbidden-title list checked independently of `cameraSignals` | New `test_parrotedScaffoldExampleTitleFailsWithoutCameraMetadata` |
+| VALID-4 | medium | `InsightOutputValidator.swift:199-208` | `hasFileNameTitle` uses **ordered** word-set equality; `"Summer garden scene"` for `summer-garden.jpg` (extra word) or `"Garden summer"` (reorder) evades it | Switch to evidence-gated **filename-stem coverage** (fraction of *stem* words echoed-and-unsupported ≥ ~0.66), not title-fraction | New `test_fileNameLeakEvadedByExtraWordFails` + FP-guard `test_descriptiveFilenameSupportedByVisionPasses` |
+| CONSIST-1 | medium ↓ | `InsightOutputValidator.swift:186-197` vs `ImageInsightCore.swift:248-252` | `hasRawOCRDump` rejects the *correct* title for a pure short sign (`"Closed For Renovation"` = 100% OCR overlap), fighting RULE 1 which mandates incorporating OCR words | Gate the dump check on OCR corpus size: only fire when `ocrWords.count >= 6` | New `test_shortSignTitleNamedAfterItsOwnTextPasses`; **re-verify** `test_titleMatchingExactOCRLine…` + `test_titleMostlyComposed…` still pass |
+| PERCEPT-3 | low | `ImagePerceptionService.swift:81-85` | `count >= 2` floor (line 81) **and** `semanticCount >= 2` (line 85) both drop single-char CJK signage (`出`, `湯`) that the OCR config explicitly enables (`ja`/`zh-Hans`/`ko`) | Relax **both** guards with `isStandaloneCJK(_:)` scalar-range helper | New `test_clean_keepsSingleCharCJKSign` (`["出","A"]` → keeps `出`) |
+| PERCEPT-1 | low ↓ | `ImagePerceptionService.swift:181-194` | Comment claims `conf ≥ 0.7` "rejects false positives that happen to be large" — an `OR` can only add matches, never reject (comment/code drift; same drift caused bug `1e423ec`) | Comment-only rewrite (do **not** flip the operator) | Covered by PERCEPT-2 extraction (makes the comment checkable) |
+
+### Diffs
+
+**VALID-1 (+CONSIST-3) — delete the dead/false-positive scaffold check** *(high)*
+Verified via git history: this entire check is part of the current uncommitted changeset; the `vintage leather suitcase` prompt example it targets was removed in the *same* changeset, so it is born dead. The only live forbidden example (`iPhone 13 Pro Max Capture`) is handled by the camera-title checks. Every reference to `.promptScaffoldLeakage` is confined to this file and consumed as an opaque `[ValidationFailure]`, so deletion compiles cleanly. **Supersedes CONSIST-3** (same code; reject CONSIST-3's "extract tokens from scaffold programmatically" — premature abstraction).
+
+```diff
+// ValidationFailure enum (line 16)
+-    case promptScaffoldLeakage
+
+// validate() call site (lines 51-53)
+-        if hasPromptScaffoldLeakage(result, input: input) {
+-            failures.append(.promptScaffoldLeakage)
+-        }
+
+// correctionHint() branch (lines 75-76)
+-            case .promptScaffoldLeakage:
+-                return "Do NOT copy wording from prompt examples or scaffold text. Use only this image's evidence."
+
+// static lists (lines 123-138) — DELETE both promptScaffoldLeakPhrases and unsupportedScaffoldConcepts
+// helper hasPromptScaffoldLeakage (lines 211-224) — DELETE entirely
+```
+Delete the two over-fit tests (`test_promptExamplePhraseFailsValidation`, `test_unsupportedSuitcaseConceptFailsValidationEvenWhenExactPromptPhraseChanges`). Keep the smoke test `test_promptScaffold_doesNotLeakRealEntityNames` (it guards the *prompt*, which is the correct layer). Add:
+```swift
+func test_legitimateLeatherSuitcasePhotoPasses() {
+    let result = makeResult(title: "Leather suitcase on a table")
+    // Apple Vision emits the synonym, not the literal word
+    let input = makeInput(visualSignals: ["Scene/object categories: luggage (88%), bag (72%)"])
+    XCTAssertEqual(InsightOutputValidator.validate(result, input: input), .passed)
+}
+```
+
+**FALLBACK-1 — content-forward document fallback title** *(medium)*
+```diff
+ case .document:
+-    return perception.recognizedText.isEmpty ? "Text-heavy image" : "Readable text in image"
++    if let firstLine = perception.recognizedText.first {
++        return "Document: \(clipped(firstLine, to: 50))"
++    }
++    return "Text-heavy image"  // defensive default (unreachable from classifier today)
+```
+
+**FALLBACK-2 — confidence-gated titling subject** *(medium)*
+```diff
++private static func confidentSubject(from perception: ImagePerceptionResult) -> String? {
++    perception.classifications
++        .filter { $0.confidence >= 0.5 && !personLikeLabels.contains(displayLabel($0.identifier)) }
++        .map { displayLabel($0.identifier) }
++        .first
++}
+// in result(): pass confidentSubject(...) to title(for:); keep usableLabels(0.2) for summary/details/tags
+```
+Test note: the hedge test must use `type: .general` — `car@0.22` cannot route to `.object` via the real classifier (object requires `> 0.7`), so an `.object`-typed test exercises an impossible state.
+
+**PERCEPT-2 — extract the routing-critical predicate** *(medium)*
+```diff
++    /// Counts a detected face if it occupies a reasonable area OR is high-confidence.
++    /// Pure + testable: faceCount drives prompt routing (portrait vs group).
++    static func shouldCountFace(area: Double, confidence: Float) -> Bool {
++        area >= 0.003 || confidence >= 0.7
++    }
+ ...
+-        return area >= 0.003 || observation.confidence >= 0.7
++        return shouldCountFace(area: Double(area), confidence: observation.confidence)
+```
+Tests: `(0.008, 0.6)→true` (bar-photo, area arm), `(0.001, 0.4)→false`, `(0.001, 0.85)→true` (confidence arm).
+
+**VALID-2 — add the missing generic prefix** *(medium)*
+```diff
+     private static let genericPrefixes = [
+         "a photograph of",
+         "an image of",
+         "a photo showing",
++        "a photo of",
+         "a picture of",
+```
+
+**VALID-3 + CONSIST-4 — single-token camera names, with FP guard** *(medium)*
+The naive `minMatches = 1` regresses on brand homonyms (`"Apple orchard"`, `"Canon in D"`), so the lone token must be model-like before flagging.
+```diff
+ private static func hasCameraModel(in text: String, cameraSignals: [String]) -> Bool {
+     let lowercaseText = text.lowercased()
+     for signal in cameraSignals {
+         guard signal.hasPrefix("Camera:") else { continue }
+         let cameraName = String(signal.dropFirst("Camera:".count)).trimmingCharacters(in: .whitespaces)
+         let significantTokens = normalizedWords(cameraName).filter(isSignificantCameraToken)
+         let matchCount = significantTokens.filter { lowercaseText.contains($0) }.count
+-        if matchCount >= 2 {
+-            return true
+-        }
++        if matchCount >= 2 { return true }
++        // Single-token model: flag only when that token is model-like (has a digit
++        // or isn't a generic camera brand word), so "Apple orchard" doesn't trip.
++        if significantTokens.count == 1, matchCount == 1, let token = significantTokens.first,
++           isModelLikeToken(token) {
++            return true
++        }
+     }
+     return false
+ }
++private static let cameraBrandStopSet: Set<String> = ["apple", "canon", "sony", "nikon", "fujifilm", "camera"]
++private static func isModelLikeToken(_ token: String) -> Bool {
++    token.contains(where: \.isNumber) || !cameraBrandStopSet.contains(token)
++}
+```
+
+**CONSIST-2 (+CONSIST-6) — close the silent-drift gap** *(medium)*
+Use prefix/word-boundary matching, **not** unbounded `.contains` (`"nature scene"` is a substring of `"Signature scene"`). Add bare `"selfie"`/`"portrait"` as exact titles (CONSIST-6's enforcement half).
+```diff
++    private static let genericFillerPrefixes = [
++        "a person standing", "portrait of someone", "a group of people",
++        "several individuals", "text on a screen", "a document showing",
++        "a beautiful landscape", "a scenic view of", "nature scene",
++        "an object on a surface", "a photo of an item"
++    ]
+ private static func hasGenericFillerTitle(_ title: String) -> Bool {
+     let lowercaseTitle = title.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+     return genericExactTitles.contains(lowercaseTitle)
+         || genericPrefixes.contains { lowercaseTitle.hasPrefix($0) }
++        || genericFillerPrefixes.contains { lowercaseTitle.hasPrefix($0) }
+ }
+// add "selfie", "portrait" to genericExactTitles
+```
+
+**CONSIST-5 — catch the parroted example without EXIF** *(medium)*
+```diff
++    private static let scaffoldForbiddenTitlePhrases = ["iphone 13 pro max capture"]
+ private static func hasGenericFillerTitle(_ title: String) -> Bool {
+     let lowercaseTitle = title.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
+     return genericExactTitles.contains(lowercaseTitle)
+         || genericPrefixes.contains { lowercaseTitle.hasPrefix($0) }
++        || scaffoldForbiddenTitlePhrases.contains { lowercaseTitle.contains($0) }
+ }
+```
+(Reject the finding's "derive the set from scaffold text" long-term idea — premature abstraction for one literal.)
+
+**VALID-4 — evidence-gated filename-stem coverage** *(medium)*
+The finding's 0.8 *title-fraction* threshold fails its own headline test (`"Summer garden scene"` → 2/3 = 0.667). Measure **filename-stem coverage** instead.
+```diff
+     let titleWords = Set(normalizedWords(title))
+     let fileWords = normalizedWords(stem)
+     guard fileWords.count >= 2 || (fileWords.first?.count ?? 0) >= 4 else { return false }
+-    return titleWords == fileWords
++    guard !fileWords.isEmpty else { return false }
++    let evidence = evidenceText(from: input)  // thread input through
++    let echoed = fileWords.filter { titleWords.contains($0) && !evidence.contains($0) }
++    // Title echoes most of the file-name stem with no visual support.
++    return Double(echoed.count) / Double(fileWords.count) >= 0.66
+```
+
+**CONSIST-1 — don't punish a short sign for naming itself** *(medium)*
+The finding's `ocrWords.count >= titleWords.count + 3` regresses both existing OCR-dump tests (6 ≥ 7 and 6 ≥ 8 are both false). Gate on absolute corpus size instead.
+```diff
+     guard titleWords.count >= 3 else { return false }
+     let ocrWords = Set(normalizedWords(ocrLines.joined(separator: " ")))
+     guard !ocrWords.isEmpty else { return false }
++    // A short self-contained sign is legitimately named after its own text (RULE 1).
++    // Only treat high overlap as a dump when the OCR corpus is substantially larger.
++    guard ocrWords.count >= 6 else { return false }
+     let overlapCount = titleWords.filter { ocrWords.contains($0) }.count
+     let overlapRatio = Double(overlapCount) / Double(titleWords.count)
+     return overlapRatio >= 0.85
+```
+Re-run `test_titleMatchingExactOCRLineFailsValidation` (6 OCR words ≥ 6 ✓) and `test_titleMostlyComposedFromOCRWordsFailsValidation` (6 ≥ 6 ✓) — both still fire; the new short-sign case (3 OCR words < 6) passes.
+
+**PERCEPT-3 — keep single-char CJK signage** *(low)*
+The finding's diff touches only line 81; line 85's `semanticCount >= 2` *also* drops a length-1 token, so as written it fails its own test. Relax **both**.
+```diff
+-            guard trimmed.count >= 2 else { continue }
++            guard trimmed.count >= 2 || isStandaloneCJK(trimmed) else { continue }
+ ...
+-            guard semanticCount >= 2, semanticRatio >= 0.5 else { continue }
++            guard semanticCount >= 2 || isStandaloneCJK(trimmed), semanticRatio >= 0.5 else { continue }
+```
+
+**PERCEPT-1 — honest comment (no operator change)** *(low)*
+Comment-only; the `OR` is the correct, empirically-validated operator (commit `1e423ec` fixed `&&`→`||` to recover the bar-photo case). Drop the "detector self-thresholds internally" rationale (unverifiable here). File uses Unicode `≥`.
+```diff
+-        //   - Confidence ≥ 0.7 rejects false positives that happen to be large (e.g. a
+-        //     face-shaped pattern in a poster, decoration, or reflection).
++        //   - Confidence ≥ 0.7 RESCUES small but high-confidence faces below the area floor;
++        //     with OR it can only add matches, never reject a large detection.
+```
+
+---
+
+## 3. Prompt & contract changes (propose-only)
+
+These alter shipping model behavior and **cannot be verified without the on-device model**. Present for human approval; do not auto-apply.
+
+**CONSIST-6 (prompt half) — reconcile the `selfie` valence** *(low)*
+The perception hint (`ImagePerceptionService.swift:43-44`, `"likely a portrait or selfie"`) and RULE 2 (`ImageInsightCore.swift:255`, `"1 = portrait or selfie"`) endorse `selfie` as a content category, while the portrait prompt (`ImageInsightCore.swift:310`) lists `"Selfie"` as a FORBIDDEN *title*. Same word, opposite valence. Keep the concept usable; forbid only the lazy one-word title:
+```diff
+// portraitPrompt FORBIDDEN line (ImageInsightCore.swift:310)
+-   ...FORBIDDEN: ... "Selfie"...
++   ...FORBIDDEN: a bare "Selfie" / "Portrait" with no descriptive content...
+```
+(The *enforcement* half — folding bare `"selfie"`/`"portrait"` into the validator — is already in §2 under CONSIST-2.)
+
+> No other §3-only items. PERCEPT-1, though originally filed as `prompt-judgment`, is a comment-only doc fix with no model-behavior change and is fully verifiable — it lives in §2 above, paired with PERCEPT-2 which makes the comment checkable against code.
+
+---
+
+## 4. Tuning judgment calls (reversible experiments)
+
+| Finding | Sev | Location | Current | Suggested | Rationale / risk |
+|---------|-----|----------|---------|-----------|------------------|
+| ROUTE-1 | medium ↓ | `ImageContentTypeClassifier.swift:37-44, 70-74` | `.landscape` requires `hasHorizon && outdoor(>0.3)` (AND-gate) | Add a 2nd branch: `salientObjectCount == 0 && outdoor(≥0.5) → .landscape` | Horizonless landscapes (forest, dune, occluded waterline, top-down snow) misroute to `.object`/`.general` and lose the scenery-tuned profile (temp 0.6/topK 4/550). **Do not** use the finding's unconditional `outdoor(≥0.5)` branch — it over-routes object-in-outdoor photos (boat+water, flower+garden, dog+park). The `salientObjectCount == 0` gate is the discriminator that steals pure scenes while leaving object photos in `.object`. Reversible. |
+| ROUTE-4 | low | `ImageContentTypeClassifier.swift:11-15, 25-35, 49-66` | ID card / badge with 1 face + light text → `.portrait` | Add `card`/`license`/`passport`/`id`/`badge` to `documentKeywords` | A loosely-shot badge (1 face, few fields, no `document` class) gets the person-framed prompt instead of reading the card. **Reject** the finding's option 1 (`≥3 lines + face → document`) — it regresses the common portrait-with-signage case. Option 2 fires only when Vision classifies a card at >0.25 *and* there are ≥3 lines, so it won't grab incidental-signage portraits. Most real licenses/passports already trip the ≥8-line heavy-text path, so blast radius is the loose-badge tail. |
+| PROFILE-1 | low ↓ | `ImageContentTypeClassifier.swift:97-103` | Retry always lowers temp 0.1 & caps topK≤2 | Branch `retryProfile(for: failures)`: tighten for hallucination/leakage; hold-steady-or-nudge-up for `.emptyDespiteSignals`/`.genericFillerTitle` | Under-specification retries push the model toward the same conservative argmax that produced the generic answer (the codebase's own comment at `AppleIntelligenceInsightsService.swift:216-219` warns argmax "miss[es] anything not in the top-1"). `allSatisfy` guard defaults any mixed/leakage set to tightening (safe). Low because the `correctionHint` is a strong opposing lever and `.emptyDespiteSignals` only fires on verbatim fallback sentinels (rare from a live FM). Reversible; conservative variant: hold temp steady rather than +0.1. |
+| VALID-6 | low | `InsightOutputValidator.swift:178-184` | `exifHits >= 2` to flag EXIF-driven content | **Leave as-is** | A lone trailing `f/2.8` slips through, but the proposed "strong-pattern fires on 1" split FPs on legit content (`"shot on location near the coast"`, `"a wide aperture for daylight"`). The ≥2 floor is a deliberate guard against incidental single-substring mentions (`iso`/`gps`/`aperture` as ordinary words). Refine only with measured FP data. |
+
+---
+
+## 5. Cross-stage consistency matrix
+
+The graded artifact. Each row is one contract rule / forbidden phrase / `@Guide`, mapped across the three enforcement stages. **Gap** classifies the mismatch. (Stages: P = prompt rule, G = `@Guide`, V = validator check.)
+
+| Contract rule | Prompt (P) | `@Guide` (G) | Validator (V) | Gap classification |
+|---------------|-----------|-------------|---------------|--------------------|
+| Incorporate OCR words into title (RULE 1) `Core:248-252` | ✅ "MUST incorporate… treat as fact" | — | ⚠️ `hasRawOCRDump` **rejects** faithful short-sign titles `Validator:186-197` | **P↔V conflict** — prompt mandates, validator punishes (CONSIST-1) |
+| No "any camera model" in title `Core:269-271,310,404` | ✅ all 6 prompts | ✅ `Service:270` | ⚠️ `hasCameraModel` needs ≥2 tokens `Validator:149-162` | **Under-enforced** — short/single-token models slip (CONSIST-4, VALID-3) |
+| Forbidden example `"iPhone 13 Pro Max Capture"` `Core:271,404` | ✅ | ✅ "no prompt examples" `Service:270` | ⚠️ caught **only** when camera EXIF present `Validator:140-162` | **Partial** — unguarded on camera-less images (CONSIST-5) |
+| Type-specific FORBIDDEN titles (12: `"A beautiful landscape"`, `"Nature scene"`, `"Portrait of someone"`, `"A group of people"`, …) `Core:310,331,351,371,390` | ✅ per type | partial | ❌ **none** of the 12 — `hasGenericFillerTitle` misses all `Validator:164-168` | **Rule with no validator** — silent drift (CONSIST-2) |
+| `"A photo of …"` generic title | ✅ (general) | — | ❌ FN — `"a photo of"` absent from `genericPrefixes` `Validator:84-95` | **Rule with no validator** (VALID-2) |
+| `selfie` as content vs lazy title `Core:255,310` + `Perception:43-44` | ⚠️ endorsed as category, forbidden as title | — | ❌ bare `"Selfie"` not in `genericExactTitles` `Validator:97-105` | **P↔P valence conflict + no validator** (CONSIST-6) |
+| No camera/EXIF in summary/title (shooting settings) `Core:269-271` | ✅ | ✅ usefulDetails-only exception | ⚠️ `hasExifDrivenContent` needs ≥2 hits `Validator:178-184` | **Under-enforced** — lone EXIF clause slips (VALID-6) |
+| No file name as title | implicit | implicit | ⚠️ `hasFileNameTitle` exact-ordered equality `Validator:199-208` | **Trivially evaded** — extra/reordered word (VALID-4) |
+| Removed `"vintage leather suitcase"` example | ❌ removed from prompt | — | ⚠️ `hasPromptScaffoldLeakage` still guards it `Validator:123-138,211-224` | **Validator with no rule** — false-positives correct output (VALID-1) |
+| Camera model in summary/details/tags | ✅ | ✅ | ✅ `hasCameraModelLeakage` `Validator:144-147` | aligned |
+| Empty/sentinel output despite signals | ✅ "use the signals" | ✅ | ✅ `hasEmptyDespiteSignals` | aligned (fires on verbatim sentinels only) |
+
+**Structural fix the matrix points to:** the type-specific FORBIDDEN lists (prompts) and the validator's filler lists drift independently. Drive both from **one shared constant** (the same list §2/CONSIST-2 introduces) so a new forbidden phrase added to a prompt cannot silently bypass the validator. This shared list should also be the source for plan **Task 3.2**'s quality-scorer generic-phrase list (see §6) — three consumers, one source of truth.
+
+---
+
+## 6. Dropped / not-pursued
+
+- **CONSIST-3** — merged into **VALID-1** (same code `hasPromptScaffoldLeakage`; VALID-1 is the git-history-confirmed superset and the only `high`). Its "extract scaffold tokens programmatically" suggestion is rejected as premature abstraction.
+- **Six `high`→`medium`/`low` downgrades** by verification (blast-radius traced): CONSIST-1, CONSIST-2, CONSIST-3, ROUTE-1, PERCEPT-1, PERCEPT-2. Output stays grounded/valid/privacy-safe in every downgraded case — these are sub-optimal-tuning or backstop-hole defects, not wrong/ungrounded content.
+- **Plan dedupe — Task 3.1 (Confidence Tuning):** owns OCR *confidence* filtering and per-sensitivity classification/face thresholds. **PERCEPT-3** (single-char CJK *length* floor) is orthogonal — a token-survival rule, not a confidence dial — so it's kept separate. The face-confidence threshold the plan exposes is the same `0.7` arm **PERCEPT-2** extracts; the extraction makes that threshold unit-testable for 3.1's benefit (fold-in, not duplicate).
+- **Plan dedupe — Task 3.2 (Quality Scoring):** the plan adds a *new post-hoc scorer/badge* with its own generic-phrase + camera-leakage lists. The validator findings here (CONSIST-2/4/5, VALID-1/2/3/4) fix the *existing `validate()` gate* that drives retry/fallback — a different layer. Fold-in: 3.2's scorer should consume the **shared filler/forbidden constant** from §5 rather than maintaining a parallel list.
+- **VALID-6** — real but parked: `exifHits >= 2` left unchanged; refine only with measured FP data (the split FPs on `"shot on location"` / `"wide aperture"`).
+- **PERCEPT-1 operator flip** — explicitly *not* pursued: the `OR` is correct and empirically validated (commit `1e423ec`). Only the stale comment is fixed.
+
+---
+
+## 7. Implementation status — §2 applied & verified (branch `fix/ai-insights-quality`)
+
+All §2, §3, and §4 fixes were implemented via TDD (watched-RED → minimal-GREEN) and verified with `xcodebuild test` on macOS (Xcode 26.5). Full test target: **76 tests, 0 failures**, including the privacy guardrail (`ImageInsightPrivacyAndProjectTests`). The one exception is **VALID-6, deliberately left as-is** per §4's own recommendation (the proposed split false-positives on legitimate content like "shot on location near the coast").
+
+| Finding | Files changed | Tests (new) |
+|---------|---------------|-------------|
+| VALID-1 (+CONSIST-3) | `InsightOutputValidator.swift` — deleted `.promptScaffoldLeakage` + both lists + helper | `test_legitimateLeatherSuitcasePhotoPasses`; removed 2 over-fit tests |
+| VALID-2 | added `"a photo of"` prefix | `test_aPhotoOfPrefixFailsValidation` |
+| VALID-3 + CONSIST-4 | single-token camera detection w/ `isModelLikeToken` + `cameraBrandStopSet` | `test_singleTokenCameraNameInTitleFails`, `test_cameraBrandHomonymInTitlePasses` |
+| CONSIST-2 (+CONSIST-6 enforcement) | `genericFillerPrefixes` (hasPrefix) + `selfie`/`portrait` exact titles | `test_typeSpecificForbiddenTitlesFailValidation` (13 phrases) |
+| CONSIST-5 | `scaffoldForbiddenTitlePhrases` checked independent of EXIF | `test_parrotedScaffoldExampleTitleFailsWithoutCameraMetadata` |
+| VALID-4 | `hasFileNameTitle` → evidence-gated stem coverage (≥0.66) | `test_fileNameLeakWithExtraWordFails`, `test_descriptiveFilenameSupportedByVisionPasses` |
+| CONSIST-1 | `hasRawOCRDump` gated on `ocrWords.count >= 6` | `test_shortSignTitleNamedAfterItsOwnTextPasses` |
+| FALLBACK-1 | `ImageInsightCore.swift` — document fallback leads with OCR via `clipped()` | `test_documentFallbackTitleIncludesOCRText` |
+| FALLBACK-2 | `confidentSubject(from:)` gates titling subject at ≥0.5 | `test_fallbackTitleHedgesWhenTopLabelIsLowConfidence` |
+| PERCEPT-2 | `ImagePerceptionService.swift` — extracted `static shouldCountFace(area:confidence:)` | `ImagePerceptionServiceTests` (3 cases) + new file registered in `project.pbxproj` |
+| PERCEPT-3 | `OCRCleaner` made internal; `isStandaloneCJK` relaxes both length floors | `test_clean_keepsSingleCharCJKSign`, `test_clean_stillDropsStraySingleLatinChar` |
+| PERCEPT-1 | comment-only: corrected the OR-cannot-reject semantics | (covered by PERCEPT-2) |
+| **CONSIST-6 (§3 prompt)** | `ImageInsightCore.swift` — portrait prompt forbids a *bare* "Selfie"/"Portrait", keeps the concept usable | (prompt text; not behaviorally testable without the model) |
+| **ROUTE-1 (§4)** | `ImageContentTypeClassifier.swift` — horizonless-landscape branch gated on `salientObjectCount == 0 && hasStrongOutdoorClassification (≥0.5)` | `test_horizonlessOutdoorSceneWithNoForegroundReturnsLandscape`, `test_outdoorSceneWithForegroundSubjectStaysObject` |
+| **ROUTE-4 (§4)** | added `card`/`license`/`passport`/`id`/`badge` to `documentKeywords` | `test_idCardWithFaceRoutesToDocument` |
+| **PROFILE-1 (§4)** | `retryProfile(for: failures)` holds steady for under-specification, tightens for leakage; wired into `AppleIntelligenceInsightsService` | `test_retryProfileHoldsSteadyForUnderSpecification`, `test_retryProfileTightensForLeakage`, `test_retryProfileTightensForMixedFailures` |
+| VALID-6 (§4) | **not changed** — left as-is per §4 recommendation (split FPs on legit content) | n/a |
+
+**Not committed** — changes sit uncommitted on the branch alongside the pre-existing quality-pipeline WIP, for review.

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,388 @@
+# Implementation Plan: High & Medium Priority AI Insights Improvements
+
+## Overview
+This plan covers 6 improvements (3 High + 3 Medium priority) to enhance the AI Insights feature. Estimated total effort: 3-4 weeks for one developer.
+
+---
+
+## Phase 1: Foundation & Caching (Week 1)
+
+### Task 1.1: Implement Vision Analysis Caching (#2 - High Priority)
+**Files to modify:**
+- [`ImagePerceptionService.swift`](StillView - Simple Image Viewer/Services/ImagePerceptionService.swift:100)
+
+**Implementation steps:**
+1. Create `PerceptionCache` actor with thread-safe access
+2. Add cache key structure: `struct CacheKey { url: URL, modDate: Date }`
+3. Implement LRU eviction (max 50 entries)
+4. Add memory pressure observer to clear cache
+5. Modify `analyze()` to check cache before running Vision requests
+6. Add cache hit/miss metrics to logging
+
+**New code structure:**
+```swift
+actor PerceptionCache {
+    private var cache: [CacheKey: ImagePerceptionResult] = [:]
+    private var accessOrder: [CacheKey] = []
+    private let maxEntries = 50
+    
+    func get(for key: CacheKey) -> ImagePerceptionResult?
+    func set(_ result: ImagePerceptionResult, for key: CacheKey)
+    func clear()
+}
+```
+
+**Testing:**
+- Add unit tests in `ImageInsightTests.swift`
+- Verify cache invalidation on file modification
+- Test memory pressure handling
+
+**Success criteria:**
+- 80%+ cache hit rate for repeated requests
+- <10ms cache lookup time
+- Proper invalidation on file changes
+
+---
+
+## Phase 2: User Experience Enhancements (Week 1-2)
+
+### Task 2.1: Progressive Loading Indicator (#5 - High Priority)
+**Files to modify:**
+- [`ImageInsightViewModel.swift`](StillView - Simple Image Viewer/ViewModels/ImageInsightViewModel.swift:5)
+- [`ImageInsightPanelView.swift`](StillView - Simple Image Viewer/Views/ImageInsightPanelView.swift:4)
+- [`ImageInsightCore.swift`](StillView - Simple Image Viewer/Models/ImageInsightCore.swift:108)
+
+**Implementation steps:**
+1. Extend `ImageInsightState` enum with detailed generating states:
+   ```swift
+   case generating(phase: GenerationPhase, progress: Double?)
+   enum GenerationPhase {
+       case analyzingImage
+       case generatingDescription
+   }
+   ```
+2. Update `AppleIntelligenceInsightsService.generateInsight()` to report progress
+3. Add progress callback mechanism through async stream
+4. Update UI to show phase-specific messages and progress bar
+5. Add estimated time calculation based on image size
+
+**UI changes:**
+- Replace generic "Generating insight…" with phase-specific text
+- Add determinate progress bar (0-100%)
+- Show estimated time remaining
+
+**Testing:**
+- Test with various image sizes
+- Verify progress updates are smooth
+- Test cancellation during each phase
+
+**Success criteria:**
+- Users see clear progress indication
+- Accurate time estimates (±20%)
+- Smooth progress bar animation
+
+### Task 2.2: Insight Export & Sharing (#10 - High Priority)
+**Files to modify:**
+- [`ImageInsightPanelView.swift`](StillView - Simple Image Viewer/Views/ImageInsightPanelView.swift:166)
+- Create new `ImageInsightExportService.swift`
+
+**Implementation steps:**
+1. Create `ImageInsightExportService` with methods:
+   - `copyToClipboard(result: ImageInsightResult)`
+   - `saveToImageMetadata(result: ImageInsightResult, imageURL: URL)`
+   - `exportAsJSON(result: ImageInsightResult) -> Data`
+   - `shareViaSystemSheet(result: ImageInsightResult, from: NSView)`
+2. Add export button menu to result section in panel
+3. Implement IPTC caption writing using ImageIO
+4. Add system share sheet integration
+5. Add user confirmation for metadata writes
+
+**UI additions:**
+```swift
+Menu {
+    Button("Copy to Clipboard") { /* ... */ }
+    Button("Save to Image Metadata") { /* ... */ }
+    Button("Export as JSON") { /* ... */ }
+    Button("Share...") { /* ... */ }
+} label: {
+    Label("Export", systemImage: "square.and.arrow.up")
+}
+```
+
+**Testing:**
+- Verify clipboard contains formatted text
+- Test IPTC metadata writing and reading
+- Verify JSON export is valid
+- Test share sheet on macOS
+
+**Success criteria:**
+- All export formats work correctly
+- Metadata writes don't corrupt images
+- Share sheet integrates properly
+
+---
+
+## Phase 3: Quality & Tuning (Week 2-3)
+
+### Task 3.1: Confidence Threshold Tuning (#1 - Medium Priority)
+**Files to modify:**
+- [`ImagePerceptionService.swift`](StillView - Simple Image Viewer/Services/ImagePerceptionService.swift:130)
+- [`PreferencesEnums.swift`](StillView - Simple Image Viewer/Models/PreferencesEnums.swift:1)
+- [`PreferencesService.swift`](StillView - Simple Image Viewer/Services/PreferencesService.swift:1)
+
+**Implementation steps:**
+1. Add `AIInsightsSensitivity` enum to preferences:
+   ```swift
+   enum AIInsightsSensitivity: String, CaseIterable {
+       case low    // More signals, lower confidence
+       case medium // Balanced (default)
+       case high   // Fewer signals, higher confidence
+   }
+   ```
+2. Create threshold configuration:
+   ```swift
+   struct PerceptionThresholds {
+       let classification: Float
+       let faceConfidence: Float
+       let faceAreaMinimum: Float
+       let ocrConfidence: Float
+   }
+   ```
+3. Update `runRequests()` to use configurable thresholds
+4. Add OCR confidence filtering (currently accepts all)
+5. Add preferences UI in AI Insights section
+
+**Threshold values:**
+- Low: classification=0.10, face=0.6, ocr=0.5
+- Medium: classification=0.15, face=0.7, ocr=0.7 (current)
+- High: classification=0.25, face=0.8, ocr=0.85
+
+**Testing:**
+- Test with images of varying quality
+- Verify threshold changes affect results
+- Test edge cases (very blurry images)
+
+**Success criteria:**
+- Users can adjust sensitivity
+- Higher sensitivity = fewer but better signals
+- Lower sensitivity = more comprehensive coverage
+
+### Task 3.2: Quality Scoring System (#9 - Medium Priority)
+**Files to modify:**
+- Create new `ImageInsightQualityAnalyzer.swift`
+- [`ImageInsightCore.swift`](StillView - Simple Image Viewer/Models/ImageInsightCore.swift:79)
+- [`AppleIntelligenceInsightsService.swift`](StillView - Simple Image Viewer/Services/AppleIntelligenceInsightsService.swift:58)
+
+**Implementation steps:**
+1. Create quality analyzer with scoring rules:
+   ```swift
+   struct QualityScore {
+       let overall: Double // 0.0-1.0
+       let issues: [QualityIssue]
+   }
+   
+   enum QualityIssue {
+       case genericFiller(phrase: String)
+       case cameraMetadataLeakage(location: String)
+       case dishonestLimitations
+       case emptyFields
+   }
+   ```
+2. Implement detection patterns:
+   - Generic phrases: "this is a photograph", "an image showing"
+   - Camera leakage: check if title/summary contains camera model
+   - Limitations honesty: sparse signals but no limitation mentioned
+3. Add quality scoring after generation
+4. Log quality metrics with each result
+5. Add optional quality badge in UI (Good/Fair/Poor)
+
+**Quality scoring algorithm:**
+- Start at 1.0
+- Deduct 0.2 for each generic filler phrase
+- Deduct 0.3 for camera metadata in title
+- Deduct 0.2 for dishonest limitations
+- Deduct 0.1 for each empty field
+
+**Testing:**
+- Create test fixtures with known quality issues
+- Verify detection accuracy
+- Test scoring consistency
+
+**Success criteria:**
+- Accurate detection of quality issues
+- Useful metrics for prompt improvement
+- Optional UI feedback for users
+
+---
+
+## Phase 4: Batch Processing (Week 3-4)
+
+### Task 4.1: Batch Insight Generation (#7 - Medium Priority)
+**Files to modify:**
+- [`ImageViewerViewModel.swift`](StillView - Simple Image Viewer/ViewModels/ImageViewerViewModel.swift:37)
+- Create new `BatchInsightGenerator.swift`
+- [`ImageInsightPanelView.swift`](StillView - Simple Image Viewer/Views/ImageInsightPanelView.swift:4)
+
+**Implementation steps:**
+1. Create `BatchInsightGenerator` actor:
+   ```swift
+   actor BatchInsightGenerator {
+       func generateForImages(
+           _ images: [ImageFile],
+           service: ImageInsightGenerating,
+           progressHandler: @escaping (Int, Int) -> Void
+       ) async throws -> [URL: ImageInsightResult]
+   }
+   ```
+2. Implement rate limiting with exponential backoff
+3. Add concurrent processing (max 2 concurrent requests)
+4. Implement cancellation support
+5. Add disk caching for batch results
+6. Create batch UI with progress sheet
+
+**UI additions:**
+- "Generate for All Images" button in panel
+- Progress sheet showing X of Y complete
+- Cancel button
+- Results summary when complete
+
+**Rate limiting strategy:**
+- Start with 500ms delay between requests
+- On rate limit error, double delay (max 8s)
+- Reset delay on successful request
+
+**Testing:**
+- Test with 10, 50, 100 images
+- Verify rate limiting works
+- Test cancellation mid-batch
+- Verify disk cache persistence
+
+**Success criteria:**
+- Can process 100+ images without errors
+- Respects rate limits gracefully
+- Results persist across app restarts
+- Clear progress indication
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- Add tests for each new component
+- Target: 80%+ code coverage for new code
+- Focus on edge cases and error handling
+
+### Integration Tests
+- Test full pipeline with caching enabled
+- Verify export formats work end-to-end
+- Test batch processing with real images
+
+### Performance Tests
+- Measure cache hit rate improvement
+- Verify batch processing throughput
+- Test memory usage under load
+
+### User Acceptance Tests
+- Test with diverse image sets
+- Verify UI responsiveness
+- Validate export functionality
+
+---
+
+## Rollout Plan
+
+### Week 1: Foundation
+- Complete caching implementation
+- Begin progressive loading indicator
+
+### Week 2: UX Polish
+- Complete progressive loading
+- Implement export functionality
+- Begin confidence tuning
+
+### Week 3: Quality
+- Complete confidence tuning
+- Implement quality scoring
+- Begin batch processing
+
+### Week 4: Batch & Polish
+- Complete batch processing
+- Integration testing
+- Bug fixes and polish
+
+---
+
+## Risk Mitigation
+
+### Technical Risks
+1. **Cache invalidation bugs**: Extensive testing with file modifications
+2. **Rate limiting issues**: Conservative initial limits, monitoring
+3. **Memory pressure**: Proper cache eviction, testing under load
+
+### User Experience Risks
+1. **Confusing progress indicators**: User testing, clear messaging
+2. **Export failures**: Robust error handling, user feedback
+3. **Batch processing overwhelming**: Cancellation support, clear limits
+
+---
+
+## Success Metrics
+
+### Performance
+- Cache hit rate: >80%
+- Batch processing: >10 images/minute
+- Export success rate: >99%
+
+### Quality
+- Quality score average: >0.7
+- User-reported issues: <5% of generations
+- Test coverage: >80%
+
+### User Satisfaction
+- Feature usage increase: >30%
+- Export feature adoption: >20% of users
+- Batch processing adoption: >10% of users
+
+---
+
+## Dependencies
+
+### External
+- macOS 26+ for Foundation Models
+- Apple Intelligence enabled
+- Sufficient disk space for caching
+
+### Internal
+- No breaking changes to existing APIs
+- Backward compatible with current preferences
+- Maintains privacy-first architecture
+
+---
+
+## Deliverables
+
+1. **Code**: All 6 features implemented and tested
+2. **Tests**: Comprehensive unit and integration tests
+3. **Documentation**: Updated inline documentation and user guide
+4. **Performance**: Benchmarks showing improvements
+5. **Migration**: Smooth upgrade path for existing users
+
+---
+
+## Reference: Original Review Summary
+
+### High Priority Items
+1. **#2 - Vision Analysis Caching**: Eliminate redundant Vision processing
+2. **#5 - Progressive Loading**: Better user feedback during generation
+3. **#10 - Export & Sharing**: Make insights actionable and persistent
+
+### Medium Priority Items
+1. **#1 - Confidence Tuning**: User-adjustable signal sensitivity
+2. **#7 - Batch Processing**: Process multiple images efficiently
+3. **#9 - Quality Scoring**: Track and improve insight quality
+
+### Architecture Principles
+- Privacy-first: All processing on-device
+- No network calls or external APIs
+- Backward compatible with existing code
+- Incremental implementation possible


### PR DESCRIPTION
## Summary

A multi-agent review of the **AI Insights generation system** (prompt contract, perception signals, classifier routing, `@Guide` constraints, and `InsightOutputValidator`), with the confirmed findings applied and test-backed. The review surfaced 25 findings → **19 confirmed** after adversarial verification; the verification pass also caught that several proposed diffs were broken (regressed their own tests) and corrected them.

> **Scope:** this reviews and fixes the *system that generates* insights, not live model outputs — FoundationModels runs on-device only. The full review write-up is in [`insight-quality-report.md`](insight-quality-report.md), including the cross-stage consistency matrix (§5) that motivated most fixes.

This branch also consolidates the in-progress quality pipeline (classify → route → generate → validate → retry) and bumps What's New to 4.1.0.

## Fixes

**Validator (`InsightOutputValidator`)**
- Remove the dead `promptScaffoldLeakage` check that now **false-positived legitimate content** (e.g. a real leather-suitcase photo) after its prompt example was removed
- Enforce the 12 type-specific FORBIDDEN-title phrases the prompts forbid but the validator never caught (silent drift)
- Catch single-token camera makes (`DJI`, `Leica`) with a brand-homonym guard so "Apple orchard" / "Samsung store" don't trip
- Gate filename-leak detection on visual evidence (was exact word-set equality, trivially evaded)
- Stop punishing short signs for naming their own OCR text (resolves the RULE 1 ↔ `hasRawOCRDump` conflict)
- Catch the parroted `"iPhone 13 Pro Max Capture"` example even with no EXIF present

**Fallback (`ImageInsightFallbackBuilder`)**
- Surface OCR text in document fallback titles (the previous branch was unreachable — always emitted a constant)
- Hedge sub-50%-confidence labels instead of stating them as confident titles

**Perception (`ImagePerceptionService`)**
- Extract + unit-test the routing-critical face-count predicate (`shouldCountFace`), which broke once already
- Keep single-character CJK signage that the 2-char floor dropped (OCR is configured for ja/zh/ko)
- Correct the misleading "OR rejects large false positives" comment

**Classifier / profile (`ImageContentTypeClassifier`)**
- Route horizonless outdoor scenes with no foreground subject to `.landscape` (gated on `salientObjectCount == 0`)
- Route ID cards / badges to `.document`
- Failure-aware `retryProfile(for:)`: hold sampling steady for under-specification, tighten for hallucination/leakage

**Prompt (`ImageInsightPromptBuilder`)**
- Portrait prompt forbids a *bare* "Selfie"/"Portrait" while keeping the concept usable

## Not changed
- **VALID-6** left as-is per the review's own recommendation — the proposed `exifHits` split false-positives on legitimate content ("shot on location near the coast").

## Testing
- Implemented via TDD (watched RED → minimal GREEN) and verified with `xcodebuild test` on macOS (Xcode 26.5).
- **Full test target: 76 tests, 0 failures**, including the privacy guardrail (`ImageInsightPrivacyAndProjectTests`) — no network/telemetry strings introduced.
- Adds `ImagePerceptionServiceTests`; expands the validator and classifier suites.

## Notes for reviewers
- Privacy invariant preserved: 100% on-device, no `URLSession`/analytics/Core ML.
- The §5 consistency matrix points at a follow-up: drive the prompt's forbidden lists and the validator's filler lists from one shared constant so they can't drift again.
- Separately surfaced (out of scope here): ~50 `*Tests.swift` files on disk are **not members of the scheme's test target** (it compiles/runs only ~76 tests) — worth a look as dormant coverage.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vscarpenter/simpleimageviewer/pull/14" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->